### PR TITLE
convert indices to int8 before stacking

### DIFF
--- a/src/grelu/sequence/format.py
+++ b/src/grelu/sequence/format.py
@@ -252,8 +252,11 @@ def strings_to_indices(
             strings
         ), "All input sequences must have the same length."
         return np.stack(
-            [[BASE_TO_INDEX_HASH[base] for base in string] for string in strings]
-        ).astype(np.int8)
+            [
+                np.array([BASE_TO_INDEX_HASH[base] for base in string], dtype(np.int8))
+                for string in strings
+            ]
+        )
 
 
 def indices_to_one_hot(indices: np.ndarray) -> Tensor:

--- a/src/grelu/sequence/format.py
+++ b/src/grelu/sequence/format.py
@@ -253,7 +253,7 @@ def strings_to_indices(
         ), "All input sequences must have the same length."
         return np.stack(
             [
-                np.array([BASE_TO_INDEX_HASH[base] for base in string], dtype(np.int8))
+                np.array([BASE_TO_INDEX_HASH[base] for base in string], dtype=np.int8)
                 for string in strings
             ]
         )


### PR DESCRIPTION
Currently, `strings_to_indices` converts all input strings to int64 arrays, stacks them, and then converts the whole array to int8. I changed this to create all the arrays as int8 in the first place so that the function uses less memory.