### PR TITLE
allow custom blacklist file

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,7 +5,7 @@ name: Publish to PyPI
 
 on:
   push:
-    tags: 
+    tags:
       - "*"
 
 jobs:

--- a/src/grelu/data/preprocess.py
+++ b/src/grelu/data/preprocess.py
@@ -332,7 +332,7 @@ def filter_overlapping(
 
 def filter_blacklist(
     data: Union[pd.DataFrame, AnnData],
-    genome: str,
+    genome: Optional[str] = None,
     blacklist: Optional[str] = None,
     inplace: bool = False,
     window: int = 0,
@@ -344,7 +344,7 @@ def filter_blacklist(
         data: Either a pandas dataframe of genomic intervals or an Anndata
             object with intervals in .var
         genome: name of the genome corresponding to intervals
-        blacklist (str): path to blacklist file. If not given, will be
+        blacklist: path to blacklist file. If not given, it will be
             extracted from the package resources.
         inplace: If True, the input is modified in place. If False, a new
             dataframe or anndata object is returned.
@@ -357,11 +357,13 @@ def filter_blacklist(
     from grelu.resources import get_blacklist_file
 
     # Read blacklist
-    if genome is not None:
-        blacklist = get_blacklist_file(genome)
-
-    if isinstance(blacklist, str):
+    if genome is None:
+        assert (
+            blacklist is not None
+        ), "Either genome name or blacklist file must be provided"
         blacklist = read_bed(blacklist, str_index=False)
+    else:
+        blacklist = get_blacklist_file(genome)
 
     # Filter
     return filter_overlapping(

--- a/src/grelu/data/preprocess.py
+++ b/src/grelu/data/preprocess.py
@@ -356,14 +356,16 @@ def filter_blacklist(
     from grelu.io.bed import read_bed
     from grelu.resources import get_blacklist_file
 
-    # Read blacklist
-    if genome is None:
+    # Get path to blacklist file
+    if genome is not None:
+        blacklist = get_blacklist_file(genome)
+    else:
         assert (
             blacklist is not None
         ), "Either genome name or blacklist file must be provided"
-        blacklist = read_bed(blacklist, str_index=False)
-    else:
-        blacklist = get_blacklist_file(genome)
+
+    # Read blacklist file
+    blacklist = read_bed(blacklist, str_index=False)
 
     # Filter
     return filter_overlapping(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 import torch
-
 import wandb
+
 from grelu.model.models import (
     BorzoiModel,
     BorzoiPretrainedModel,


### PR DESCRIPTION
Previous logic did not allow the user to supply a custom blacklist file in `filter_blacklist` (see #9). Now, we first check if `genome=None` in which case we accept a custom blacklist file supplied by the user.