### PR TITLE
replaced .A with .toarray()

### DIFF
--- a/src/grelu/data/dataset.py
+++ b/src/grelu/data/dataset.py
@@ -330,7 +330,7 @@ class AnnDataSeqDataset(LabeledSeqDataset):
         # Get the labels
         if label_key is None:
             if scipy.sparse.issparse(adata.X):
-                labels = adata.X.A.T
+                labels = adata.X.toarray().T
             else:
                 labels = adata.X.T
 


### PR DESCRIPTION
scipy has removed support for the `.A` method in sparse arrays (https://github.com/scipy/scipy/issues/21049). Replaced this with `.toarray()`.