### PR TITLE
Pin torchmetrics version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ install_requires =
     pymemesuite
     torch >= 2.0
     pytorch-lightning >= 2.0
+    torchmetrics >= 1.1
     modisco-lite >= 2.2.1
     biopython
     enformer-pytorch


### PR DESCRIPTION
to fix the following error:

```pytb
model = grelu.resources.load_model(project="borzoi",model_name="human_fold0", device='cuda:0')

File ~/mambaforge/envs/scverse/lib/python3.11/site-packages/grelu/lightning/metrics.py:137, in PearsonCorrCoef.__init__(self, num_outputs, average)
    135 def __init__(self, num_outputs: int = 1, average: bool = True) -> None:
    136     super().__init__()
--> 137     self.pearson = torchmetrics.PearsonCorrCoef(num_outputs=num_outputs)
    138     self.average = average

TypeError: PearsonCorrCoef.__init__() got an unexpected keyword argument 'num_outputs'
```