### PR TITLE
updated merge_intervals function to account for strand

### DIFF
--- a/docs/tutorials/1_inference.ipynb
+++ b/docs/tutorials/1_inference.ipynb
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "8be6f301-a23c-4a1b-ba25-1df11c4b2e19",
    "metadata": {},
    "outputs": [
@@ -61,10 +61,10 @@
      "text": [
       "/usr/local/lib/python3.11/dist-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n",
-      "\u001b[34m\u001b[1mwandb\u001b[0m: Currently logged in as: \u001b[33mavantikalal\u001b[0m (\u001b[33mgrelu\u001b[0m). Use \u001b[1m`wandb login --relogin`\u001b[0m to force relogin\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Currently logged in as: \u001b[33manony-moose-1905623316140963\u001b[0m. Use \u001b[1m`wandb login --relogin`\u001b[0m to force relogin\n",
       "\u001b[34m\u001b[1mwandb\u001b[0m: Downloading large artifact human_fold0:latest, 711.00MB. 1 files... \n",
       "\u001b[34m\u001b[1mwandb\u001b[0m:   1 of 1 files downloaded.  \n",
-      "Done. 0:0:1.2\n"
+      "Done. 0:0:1.1\n"
      ]
     }
    ],
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "5bf5576c-9c1f-4411-b5cf-2b61ff33c1dc",
    "metadata": {},
    "outputs": [
@@ -104,7 +104,7 @@
        "dict_keys(['tasks', 'train_seq_len', 'train_label_len', 'train_genome', 'train_bin_size'])"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "520eb16f-29a9-46cd-8f7b-c42d6f67b031",
    "metadata": {},
    "outputs": [
@@ -156,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "feb8cf06-1a1d-4f31-8a33-a97d119040c4",
    "metadata": {},
    "outputs": [
@@ -259,7 +259,7 @@
        "2  SABiosciences XpressRef Human Universal Total ...  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -287,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "990f8913-b3fd-4166-a78a-0c99cb217e8d",
    "metadata": {},
    "outputs": [],
@@ -308,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "79b962b8-7303-4051-999e-7732645dc773",
    "metadata": {},
    "outputs": [
@@ -356,7 +356,7 @@
        "0  chr1  69993520  70517808      +"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -387,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "f5dbca5a-3ed0-4755-89a2-055197cd5a65",
    "metadata": {},
    "outputs": [
@@ -397,7 +397,7 @@
        "524288"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -420,12 +420,12 @@
    "id": "57335ba4-1ac6-4014-8e38-438330d04243",
    "metadata": {},
    "source": [
-    "This is a very long sequence - let's just look at the beginning."
+    "This is a very long sequence - don't try to print the whole thing! Let's just look at the beginning."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "024fe28b-a1e9-4db0-b61a-300244a9c6aa",
    "metadata": {},
    "outputs": [
@@ -435,7 +435,7 @@
        "'ACTGTGCACC'"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -464,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "a4cfdf2a-8efc-426e-8410-bba771a02512",
    "metadata": {},
    "outputs": [
@@ -472,8 +472,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.67 s, sys: 628 ms, total: 3.3 s\n",
-      "Wall time: 1.34 s\n"
+      "CPU times: user 3.5 s, sys: 899 ms, total: 4.4 s\n",
+      "Wall time: 2.61 s\n"
      ]
     },
     {
@@ -482,7 +482,7 @@
        "(1, 7611, 6144)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -521,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "54dcbae2-84fe-4aab-be86-194c2a00d57b",
    "metadata": {},
    "outputs": [
@@ -569,7 +569,7 @@
        "0  chr1  70157360  70353968      +"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -581,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "fa3784aa-18f1-4ec1-8a7b-676f32a914b6",
    "metadata": {},
    "outputs": [
@@ -626,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "id": "c2861b86-c15c-43ec-bea6-8985af8b902b",
    "metadata": {},
    "outputs": [],
@@ -645,7 +645,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "id": "c41fff9e-0076-4bf5-9111-9c5061ea42f2",
    "metadata": {},
    "outputs": [
@@ -671,7 +671,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "id": "a4bd82e0-9925-4198-bbb3-3570bf6c7a25",
    "metadata": {},
    "outputs": [
@@ -736,7 +736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "id": "7e29cb51-1ed8-4d9d-a5d4-aa04baea12ca",
    "metadata": {},
    "outputs": [
@@ -829,7 +829,7 @@
        "3  gene_id \"DDX11L1\"; transcript_id \"NR_046018.2\"...  "
       ]
      },
-     "execution_count": 18,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -851,7 +851,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "id": "90fbec2f-8625-4b20-a096-ae8867181097",
    "metadata": {},
    "outputs": [
@@ -951,7 +951,7 @@
        "176832     .  gene_id \"LRRC40\"; transcript_id \"XM_047424520....  "
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -977,7 +977,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "id": "4e8d2b7d-5d73-48ac-baa7-adf00501d756",
    "metadata": {},
    "outputs": [
@@ -1070,7 +1070,7 @@
        "176832     .  gene_id \"LRRC40\"; transcript_id \"XM_047424520....  "
       ]
      },
-     "execution_count": 20,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1090,7 +1090,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "id": "d6bcd377-40a0-45af-84ad-d17213ac82b9",
    "metadata": {},
    "outputs": [
@@ -1119,6 +1119,7 @@
        "      <th>chrom</th>\n",
        "      <th>start</th>\n",
        "      <th>end</th>\n",
+       "      <th>strand</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1128,6 +1129,7 @@
        "      <td>chr1</td>\n",
        "      <td>70258999</td>\n",
        "      <td>70336099</td>\n",
+       "      <td>-</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -1135,6 +1137,7 @@
        "      <td>chr1</td>\n",
        "      <td>70159330</td>\n",
        "      <td>70205579</td>\n",
+       "      <td>-</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -1142,26 +1145,27 @@
        "      <td>chr1</td>\n",
        "      <td>70205696</td>\n",
        "      <td>70253052</td>\n",
+       "      <td>+</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "  gene_name chrom     start       end\n",
-       "0  ANKRD13C  chr1  70258999  70336099\n",
-       "1    LRRC40  chr1  70159330  70205579\n",
-       "2    SRSF11  chr1  70205696  70253052"
+       "  gene_name chrom     start       end strand\n",
+       "0  ANKRD13C  chr1  70258999  70336099      -\n",
+       "1    LRRC40  chr1  70159330  70205579      -\n",
+       "2    SRSF11  chr1  70205696  70253052      +"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "output_genes = grelu.data.preprocess.merge_intervals_by_column(\n",
-    "    output_exons.iloc[:, :4], group_col=\"gene_name\"\n",
+    "    output_exons, group_col=\"gene_name\"\n",
     ")\n",
     "output_genes"
    ]
@@ -1184,7 +1188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "id": "e0504512-30c3-4a4b-b217-815a3b5d310c",
    "metadata": {},
    "outputs": [
@@ -1228,7 +1232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "id": "538051eb-0166-425e-885a-b5f49747b6b0",
    "metadata": {},
    "outputs": [
@@ -1238,7 +1242,7 @@
        "(8, 4096, 4096)"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1266,7 +1270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "id": "8d8ae6fd-60d2-45e8-93e2-4730d6da7bec",
    "metadata": {},
    "outputs": [
@@ -1276,7 +1280,7 @@
        "(4096, 4096)"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1296,7 +1300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "id": "cf804d5f-263f-432e-b147-57242696efcc",
    "metadata": {},
    "outputs": [
@@ -1415,7 +1419,7 @@
        "8        SRSF11  chr1  70205696  70253052"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1435,7 +1439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "id": "1c71babc-7ab3-4be6-98cd-79e8385fde9e",
    "metadata": {},
    "outputs": [
@@ -1479,7 +1483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "id": "9b779f35-309c-4739-be8e-f9dddcba3c8e",
    "metadata": {},
    "outputs": [
@@ -1498,7 +1502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "id": "38deae4b-3d6b-49f8-9ddb-ff614d12d844",
    "metadata": {},
    "outputs": [
@@ -1525,7 +1529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "id": "4af3971e-6b90-4d58-b272-ae3d81e71a1b",
    "metadata": {},
    "outputs": [
@@ -1628,7 +1632,7 @@
        "7539   RNA                                 brain  "
       ]
      },
-     "execution_count": 29,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1639,7 +1643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "id": "66cf4f02-e7d6-45d1-9b2f-1d61d0084f8d",
    "metadata": {},
    "outputs": [
@@ -1742,7 +1746,7 @@
        "6146  liver tissue female embryo (20 weeks) and male...  "
       ]
      },
-     "execution_count": 30,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1761,7 +1765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 30,
    "id": "c9d49ff7-c19a-45b1-980f-13a84eee4203",
    "metadata": {},
    "outputs": [
@@ -1854,7 +1858,7 @@
        "176931     .  gene_id \"SRSF11\"; transcript_id \"XM_047434541....  "
       ]
      },
-     "execution_count": 31,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1874,7 +1878,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "id": "74d97b63-781d-49f5-bf79-7f8a2d062121",
    "metadata": {},
    "outputs": [
@@ -1930,7 +1934,7 @@
        "176931   2220  2225"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1953,7 +1957,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 32,
    "id": "6b908eec-f13f-4916-8121-4d811784629b",
    "metadata": {},
    "outputs": [
@@ -1987,7 +1991,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "id": "c19bdf28-f603-42e8-81a6-378d83c8fe43",
    "metadata": {},
    "outputs": [],
@@ -2015,7 +2019,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 34,
    "id": "8e24f251-9f35-4729-bdd5-ea797871e5d8",
    "metadata": {},
    "outputs": [
@@ -2025,7 +2029,7 @@
        "array([[[1.6088623]]], dtype=float32)"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2060,7 +2064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "id": "bd7bc0df-ae98-4076-9a35-df0811d88603",
    "metadata": {},
    "outputs": [
@@ -2080,7 +2084,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 36,
    "id": "d135eb2d-827d-440c-9536-5241b19e033f",
    "metadata": {
     "scrolled": true
@@ -2092,19 +2096,17 @@
      "text": [
       "GPU available: True (cuda), used: True\n",
       "TPU available: False, using: 0 TPU cores\n",
-      "IPU available: False, using: 0 IPUs\n",
       "HPU available: False, using: 0 HPUs\n",
-      "Missing logger folder: /code/gReLU/docs/tutorials/lightning_logs\n",
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [4]\n"
+      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0,1,2,3,4,5,6,7]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Predicting DataLoader 0: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [01:28<00:00,  1.13it/s]\n",
-      "CPU times: user 1min 36s, sys: 2.47 s, total: 1min 38s\n",
-      "Wall time: 1min 39s\n"
+      "Predicting DataLoader 0: 100%|████████████████| 100/100 [01:31<00:00,  1.10it/s]\n",
+      "CPU times: user 1min 38s, sys: 2.53 s, total: 1min 41s\n",
+      "Wall time: 1min 41s\n"
      ]
     },
     {
@@ -2113,7 +2115,7 @@
        "(4, 200)"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2147,7 +2149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 37,
    "id": "0f83e72d-4452-4283-8a60-442b351097fc",
    "metadata": {},
    "outputs": [
@@ -2224,7 +2226,7 @@
        "T  0.000046  0.000599 -0.004783  0.000000  0.000000"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2243,7 +2245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 38,
    "id": "9e4b4269-de96-4659-b3e7-c1dcf57b4c1c",
    "metadata": {},
    "outputs": [
@@ -2253,7 +2255,7 @@
        "<Axes: >"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2274,17 +2276,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 39,
    "id": "fca8b9bd-05cd-4057-8bdc-f9cd017eeddf",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<logomaker.src.Logo.Logo at 0x7f7c61f52ed0>"
+       "<logomaker.src.Logo.Logo at 0x7fbaee1ab310>"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2336,7 +2338,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #63 

1. The `merge_intervals_by_column` function, which merges groups of genomic intervals into a single interval, previously did not return the strand of the merged intervals. Now, if a strand column is provided in the input, we check that all intervals in the same group have the same strand, and return this strand column in the output.

2. Added a test for this function

3. Reran tutorial 1 which uses this function.
