### PR TITLE
Add onehot encoding dataset

### DIFF
--- a/src/grelu/data/dataset.py
+++ b/src/grelu/data/dataset.py
@@ -132,7 +132,21 @@ class LabeledOneHotDataset(Dataset):
             transform_func=self.label_transform_func,
         )
 
+        # Create augmenter
+        self.augmenter = Augmenter(
+            rc=self.rc,
+            max_seq_shift=self.max_seq_shift,
+            max_pair_shift=self.max_pair_shift,
+            seq_len=self.seq_len,
+            label_len=self.label_len,
+            seed=seed,
+            mode=augment_mode,
+        )
+        self.n_augmented = len(self.augmenter)
         self.n_alleles = 1
+
+        # Set mode
+        self.predict = False
 
         # Set mode
         self.predict = False


### PR DESCRIPTION
Hi, I notice that the class "class LabeledSeqDataset(Dataset)" actually does not accept one hot encoding as inputs, as it needs to transfer the strins to indices. Therefore, I add a new class for using one hot encoding as inputs. it will be extremely helpful for multi-sequence inputs and the combination inputs.