### PR TITLE
Flash Attention support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorchlightning/pytorch_lightning:base-cuda-py3.11-torch2.2-cuda12.1.0
+FROM pytorch/pytorch:2.4.1-cuda12.1-cudnn9-devel
 
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -31,6 +31,7 @@ RUN rsync -aP rsync://hgdownload.soe.ucsc.edu/genome/admin/exe/linux.x86_64/gff3
 
 
 # Install python packages
+RUN pip install flash-attn --no-build-isolation
 RUN pip install cython setuptools jupyterlab pandas scikit-learn tables lxml html5lib
 RUN pip install pytest pytest-cov pre-commit
 RUN pip install black flake8 isort
@@ -54,4 +55,4 @@ RUN wget https://meme-suite.org/meme/meme-software/5.5.1/meme-5.5.1.tar.gz && \
 
 # Run jupyterlab
 WORKDIR /
-CMD jupyter lab --no-browser --allow-root --port 8891 --ip 0.0.0.0 --NotebookApp.token=''
+# CMD jupyter lab --no-browser --allow-root --port 8891 --ip 0.0.0.0 --NotebookApp.token=''

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,4 @@ RUN wget https://meme-suite.org/meme/meme-software/5.5.1/meme-5.5.1.tar.gz && \
 
 # Run jupyterlab
 WORKDIR /
-# CMD jupyter lab --no-browser --allow-root --port 8891 --ip 0.0.0.0 --NotebookApp.token=''
+CMD jupyter lab --no-browser --allow-root --port 8891 --ip 0.0.0.0 --NotebookApp.token=''

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ conda install -c conda-forge cudatoolkit-dev -y
 pip install torch ninja
 pip install flash-attn --no-build-isolation
 pip install gReLU
-``` 
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To install using pip:
 pip install gReLU
 ```
 
-To install and use [flash-attn](https://github.com/Dao-AILab/flash-attention), flash-attn needs to be installed first:
+To train or use transformer models containing flash attention layers, [flash-attn](https://github.com/Dao-AILab/flash-attention) needs to be installed first:
 ```shell
 conda install -c conda-forge cudatoolkit-dev -y
 pip install torch ninja

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ To install using pip:
 pip install gReLU
 ```
 
+To install and use [flash-attn](https://github.com/Dao-AILab/flash-attention), flash-attn needs to be installed first:
+```shell
+conda install -c conda-forge cudatoolkit-dev -y
+pip install torch ninja
+pip install flash-attn --no-build-isolation
+pip install gReLU
+``` 
+
 ## Contributing
 
 This project uses [pre-commit](https://pre-commit.com/). Please make sure to install it before making any changes:

--- a/src/grelu/model/blocks.py
+++ b/src/grelu/model/blocks.py
@@ -708,9 +708,9 @@ class TransformerBlock(nn.Module):
         if flash_attn:
 
             print(
-                "WARNING: FlashAttention does not use pos_dropout, key_len, value_len, n_pos_features arguments. Ignore if you are loading a pre-trained model."
+                "WARNING: FlashAttention does not use pos_dropout, key_len, value_len, n_pos_features arguments. \
+                Ignore if you are loading a pre-trained model."
             )
-            # note pos_dropout, key_len, value_len, n_pos_features not used
             self.mha = FlashAttention(
                 embed_dim=in_len,
                 n_heads=n_heads,

--- a/src/grelu/model/blocks.py
+++ b/src/grelu/model/blocks.py
@@ -774,6 +774,8 @@ class TransformerTower(nn.Module):
         pos_dropout: Dropout probability in the positional embeddings
         attn_dropout: Dropout probability in the output layer
         ff_droppout: Dropout probability in the linear feed-forward layers
+        flash_attn: If True, uses Flash Attention with Rotational Position Embeddings. key_len, value_len,
+            pos_dropout and n_pos_features are ignored.
         dtype: Data type of the weights
         device: Device on which to store the weights
     """

--- a/src/grelu/model/blocks.py
+++ b/src/grelu/model/blocks.py
@@ -706,6 +706,8 @@ class TransformerBlock(nn.Module):
         self.norm = Norm("layer", in_len)
 
         if flash_attn:
+
+            print("WARNING: FlashAttention does not use pos_dropout, key_len, value_len, n_pos_features arguments. Ignore if you are loading a pre-trained model.")
             # note pos_dropout, key_len, value_len, n_pos_features not used
             self.mha = FlashAttention(
                 embed_dim=in_len,

--- a/src/grelu/model/blocks.py
+++ b/src/grelu/model/blocks.py
@@ -2,8 +2,8 @@
 Blocks composed of multiple layers.
 """
 
-from typing import List, Optional, Union
 import warnings
+from typing import List, Optional, Union
 
 import torch
 from einops import rearrange

--- a/src/grelu/model/blocks.py
+++ b/src/grelu/model/blocks.py
@@ -10,11 +10,11 @@ from torch import Tensor, nn
 
 from grelu.model.layers import (
     Activation,
-    FlashAttention,
     Attention,
     ChannelTransform,
     Crop,
     Dropout,
+    FlashAttention,
     Norm,
     Pool,
 )
@@ -707,14 +707,16 @@ class TransformerBlock(nn.Module):
 
         if flash_attn:
 
-            print("WARNING: FlashAttention does not use pos_dropout, key_len, value_len, n_pos_features arguments. Ignore if you are loading a pre-trained model.")
+            print(
+                "WARNING: FlashAttention does not use pos_dropout, key_len, value_len, n_pos_features arguments. Ignore if you are loading a pre-trained model."
+            )
             # note pos_dropout, key_len, value_len, n_pos_features not used
             self.mha = FlashAttention(
                 embed_dim=in_len,
                 n_heads=n_heads,
                 dropout_p=attn_dropout,
                 dtype=dtype,
-                device=device
+                device=device,
             )
         else:
             self.mha = Attention(
@@ -727,7 +729,7 @@ class TransformerBlock(nn.Module):
                 attn_dropout=attn_dropout,
                 dtype=dtype,
                 device=device,
-        )
+            )
         self.dropout = Dropout(ff_dropout)
         self.ffn = FeedForwardBlock(
             in_len=in_len,

--- a/src/grelu/model/layers.py
+++ b/src/grelu/model/layers.py
@@ -466,7 +466,8 @@ class FlashAttention(nn.Module):
             from flash_attn.layers.rotary import RotaryEmbedding
         except ImportError:
             raise ImportError(
-                "gReLU needs to be installed with flash-attn to use Flash Attention. Please see README for instructions."
+                "gReLU needs to be installed with flash-attn to use Flash Attention. \
+                    Please see README for instructions."
             )
 
         self.embed_dim = embed_dim

--- a/src/grelu/model/layers.py
+++ b/src/grelu/model/layers.py
@@ -450,7 +450,6 @@ class FlashAttention(nn.Module):
         self,
         embed_dim: int,
         n_heads: int,
-        window_size=(256, 256),
         dropout_p=0.0,
         device=None,
         dtype=None

--- a/src/grelu/model/layers.py
+++ b/src/grelu/model/layers.py
@@ -11,6 +11,8 @@ from torch import Tensor, einsum, nn
 
 from grelu.model.position import get_central_mask
 
+from flash_attn import flash_attn_qkvpacked_func
+from flash_attn.layers.rotary import RotaryEmbedding
 
 class Activation(nn.Module):
     """
@@ -442,3 +444,55 @@ class Attention(nn.Module):
         out = einsum("b h i j, b h j d -> b h i d", attn, v)
         out = rearrange(out, "b h n d -> b n (h d)")
         return self.to_out(out)
+
+class FlashAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dim: int,
+        n_heads: int,
+        window_size=(256, 256),
+        dropout_p=0.0,
+        device=None,
+        dtype=None
+    ):
+        super().__init__()
+        
+        self.embed_dim = embed_dim
+        self.n_heads = n_heads
+        self.head_dim = embed_dim // n_heads
+        self.dropout_p = dropout_p
+
+        # Create linear layers
+        self.qkv = nn.Linear(
+            self.embed_dim, self.embed_dim * 3, bias=False, device=device, dtype=dtype
+        )
+        self.out = nn.Linear(self.embed_dim, self.embed_dim, device=device, dtype=dtype)
+
+        # positional encoding
+        self.rotary_embed = RotaryEmbedding(self.head_dim, device=device)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """
+        Forward pass
+
+        Args:
+            x : Input tensor of shape (batch_size, seq_len, embed_dim)
+
+        Returns:
+            Output tensor
+        """
+        qkv = rearrange(
+            self.qkv(x),
+            "b l (qkv nheads headdim) -> b l qkv nheads headdim",
+            qkv=3,
+            nheads=self.n_heads,
+            headdim=self.head_dim,
+        )
+        qkv = self.rotary_embed(qkv)
+        out = rearrange(
+            flash_attn_qkvpacked_func(
+                qkv, self.dropout_p, window_size=(-1,-1)
+            ),
+            "b l nheads headdim -> b l (nheads headdim)",
+        )
+        return self.out(out)

--- a/src/grelu/model/layers.py
+++ b/src/grelu/model/layers.py
@@ -443,14 +443,10 @@ class Attention(nn.Module):
         out = rearrange(out, "b h n d -> b n (h d)")
         return self.to_out(out)
 
+
 class FlashAttention(nn.Module):
     def __init__(
-        self,
-        embed_dim: int,
-        n_heads: int,
-        dropout_p=0.0,
-        device=None,
-        dtype=None
+        self, embed_dim: int, n_heads: int, dropout_p=0.0, device=None, dtype=None
     ):
         """
         Flash Attention layer with RoPE for positional encoding.
@@ -466,10 +462,12 @@ class FlashAttention(nn.Module):
         super().__init__()
 
         try:
-            from flash_attn.layers.rotary import RotaryEmbedding
             from flash_attn import flash_attn_qkvpacked_func
+            from flash_attn.layers.rotary import RotaryEmbedding
         except ImportError:
-            raise ImportError("gReLU needs to be installed with flash-attn to use Flash Attention. Please see README for instructions.")
+            raise ImportError(
+                "gReLU needs to be installed with flash-attn to use Flash Attention. Please see README for instructions."
+            )
 
         self.embed_dim = embed_dim
         self.n_heads = n_heads
@@ -484,7 +482,7 @@ class FlashAttention(nn.Module):
 
         # positional encoding
         self.rotary_embed = RotaryEmbedding(self.head_dim, device=device)
-        
+
         # no parameters, just an operation
         self.flash_attn_qkvpacked_func = flash_attn_qkvpacked_func
 
@@ -507,9 +505,7 @@ class FlashAttention(nn.Module):
         )
         qkv = self.rotary_embed(qkv)
         out = rearrange(
-            self.flash_attn_qkvpacked_func(
-                qkv, self.dropout_p, window_size=(-1,-1)
-            ),
+            self.flash_attn_qkvpacked_func(qkv, self.dropout_p, window_size=(-1, -1)),
             "b l nheads headdim -> b l (nheads headdim)",
         )
         return self.out(out)

--- a/src/grelu/model/layers.py
+++ b/src/grelu/model/layers.py
@@ -452,10 +452,24 @@ class FlashAttention(nn.Module):
         device=None,
         dtype=None
     ):
+        """
+        Flash Attention layer with RoPE for positional encoding.
+
+        Args:
+            embed_dim: Number of channels
+            n_heads: Number of attention heads
+            dropout_p: Dropout probability for attention
+            device: Device for the layers.
+            dtype: Data type for the layers.
+        """
+
         super().__init__()
 
-        from flash_attn.layers.rotary import RotaryEmbedding
-        from flash_attn import flash_attn_qkvpacked_func
+        try:
+            from flash_attn.layers.rotary import RotaryEmbedding
+            from flash_attn import flash_attn_qkvpacked_func
+        except ImportError:
+            raise ImportError("gReLU needs to be installed with flash-attn to use Flash Attention. Please see README for instructions.")
 
         self.embed_dim = embed_dim
         self.n_heads = n_heads

--- a/src/grelu/model/models.py
+++ b/src/grelu/model/models.py
@@ -511,6 +511,7 @@ class BorzoiModel(BaseModel):
         crop_len: int = 16,
         final_act_func: Optional[str] = None,
         final_pool_func: Optional[str] = "avg",
+        flash_attn=False,
         dtype=None,
         device=None,
     ) -> None:
@@ -530,6 +531,7 @@ class BorzoiModel(BaseModel):
                 n_heads=n_heads,
                 n_pos_features=n_pos_features,
                 crop_len=crop_len,
+                flash_attn=flash_attn,
                 dtype=dtype,
                 device=device,
             ),

--- a/src/grelu/model/models.py
+++ b/src/grelu/model/models.py
@@ -484,6 +484,8 @@ class BorzoiModel(BaseModel):
         head_act_func: Name of the activation function to use in the final layer
         final_pool_func: Name of the pooling function to apply to the final output.
             If None, no pooling will be applied at the end.
+        flash_attn: If True, uses Flash Attention with Rotational Position Embeddings. key_len, value_len,
+            pos_dropout and n_pos_features are ignored.
         dtype: Data type for the layers.
         device: Device for the layers.
     """

--- a/src/grelu/model/trunks/borzoi.py
+++ b/src/grelu/model/trunks/borzoi.py
@@ -118,6 +118,8 @@ class BorzoiTrunk(nn.Module):
         n_heads: Number of attention heads
         n_pos_features: Number of positional features
         crop_len: Length of the crop
+        flash_attn: If True, uses Flash Attention with Rotational Position Embeddings. key_len, value_len,
+            pos_dropout and n_pos_features are ignored.
         norm_type: Type of normalization to apply: 'batch', 'syncbatch', 'layer', 'instance' or None
         norm_kwargs: Additional arguments to be passed to the normalization layer
         dtype: Data type for the layers.

--- a/src/grelu/model/trunks/borzoi.py
+++ b/src/grelu/model/trunks/borzoi.py
@@ -144,6 +144,7 @@ class BorzoiTrunk(nn.Module):
         n_pos_features: int,
         # Crop
         crop_len: int,
+        flash_attn: bool,
         norm_type="batch",
         norm_kwargs=None,
         dtype=None,
@@ -172,6 +173,7 @@ class BorzoiTrunk(nn.Module):
             attn_dropout=attn_dropout,
             n_heads=n_heads,
             n_pos_features=n_pos_features,
+            flash_attn=flash_attn,
             dtype=dtype,
             device=device,
         )


### PR DESCRIPTION
- added support for Flash Attention layers
- Added a `flash_attn` flag in `BorzoiModel` that switches to flash attention. 
- updated Dockerfile to use pytorch dev image, which has cudatoolkit required by `flash-attn`. Dockerfile includes `flash-attn`. 
- Installation is a bit more involved, so I have updated README with instructions. However, simple `pip install gReLU` still works if `flash-attn` is not required as it is only imported when called. 

Solves #64 