### PR TITLE
add multiomial axis option to poisson multinomial loss

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 import torch
-
 import wandb
+
 from grelu.model.models import (
     BorzoiModel,
     BorzoiPretrainedModel,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 import torch
-import wandb
 
+import wandb
 from grelu.model.models import (
     BorzoiModel,
     BorzoiPretrainedModel,


### PR DESCRIPTION
Addresses #68 
Allows computation of multinomial distribution along the length axis (e.g. Borzoi) or along the task axis (e.g. Decima).