### PR TITLE
Fix CI failure

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -813,14 +813,14 @@ def test_marginalize_dataset_variants():
     assert convert_input_type(ds.seqs, "strings") == ["CATACGTGAGGC", "AGGAGGCCAAAG"]
     xs = [convert_input_type(ds[i], "strings") for i in range(len(ds))]
     assert xs == [
-        "CACGTGTGAGGC",
-        "CACGTATGAGGC",
-        "CACGAGAGTGGC",
-        "CACGAAAGTGGC",
-        "AAGGGGGCCAAG",
-        "AAGGGAGCCAAG",
-        "AAGAGGGCCAAG",
-        "AAGAGAGCCAAG",
+        "CACGGGATGAGC",
+        "CACGGAATGAGC",
+        "CACGGGTAGTGC",
+        "CACGGATAGTGC",
+        "AAAGGGAGCCAG",
+        "AAAGGAAGCCAG",
+        "AGGGAGGCCAAG",
+        "AGGGAAGCCAAG",
     ]
 
 
@@ -841,13 +841,13 @@ def test_marginalize_dataset_motifs():
     xs = [convert_input_type(ds[i], "strings") for i in range(len(ds))]
     bg = convert_input_type(ds.bg, "strings")
 
-    assert bg == ["ACGCATACGAGCGCTACAGCAACATAAAAC", "ACTAACAACAGCACGCGCGATATAAGCAAC"]
+    assert bg == ["ACAACGCTAGACACGCGCAGCAATATAAAC", "AAAACAGCGCTAACGAGCACGCATATACAC"]
 
     assert xs == [
-        "ACGCATACGAGCGCTACAGCAACATAAAAC",
-        "ACGCATACGAGCGAAACAGCAACATAAAAC",
-        "ACTAACAACAGCACGCGCGATATAAGCAAC",
-        "ACTAACAACAGCAAAAGCGATATAAGCAAC",
+        "ACAACGCTAGACACGCGCAGCAATATAAAC",
+        "ACAACGCTAGACAAAAGCAGCAATATAAAC",
+        "AAAACAGCGCTAACGAGCACGCATATACAC",
+        "AAAACAGCGCTAAAAAGCACGCATATACAC",
     ]
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -839,6 +839,10 @@ def test_marginalize_dataset_motifs():
     )
 
     xs = [convert_input_type(ds[i], "strings") for i in range(len(ds))]
+    bg = convert_input_type(ds.bg, "strings")
+
+    assert bg == ["ACGCATACGAGCGCTACAGCAACATAAAAC", "ACTAACAACAGCACGCGCGATATAAGCAAC"]
+
     assert xs == [
         "ACGCATACGAGCGCTACAGCAACATAAAAC",
         "ACGCATACGAGCGAAACAGCAACATAAAAC",

--- a/tests/test_interpret.py
+++ b/tests/test_interpret.py
@@ -88,7 +88,7 @@ def test_marginalize_patterns():
     assert preds_after.shape == (2, 3, 1)
     assert np.allclose(
         preds_after.squeeze(),
-        [[0.5, 0.8333333, 0.8333333], [1.3333334, 1.6666666, 1.6666666]],
+        [[0.8333333, 0.5, 0.8333333], [1.6666666, 1.3333334, 1.6666666]],
     )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 import torch
-import wandb
 
+import wandb
 from grelu.model.models import (
     BorzoiModel,
     BorzoiPretrainedModel,


### PR DESCRIPTION
Tests were failing due to a change in tangermeme 0.4.1 giving different (but still correct) dinucleotide-shuffled sequences from before. This is resolved by changing the expected output of the tests.