### PR TITLE
Prevent padded intervals from exceeding chromosome ends

### DIFF
--- a/src/grelu/data/dataset.py
+++ b/src/grelu/data/dataset.py
@@ -16,7 +16,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 
 from grelu.data.augment import Augmenter, _split_overall_idx
-from grelu.data.preprocess import filter_chrom_ends
+from grelu.data.preprocess import check_chrom_ends
 from grelu.data.utils import _check_multiclass, _create_task_data
 from grelu.sequence.format import (
     INDEX_TO_BASE_HASH,
@@ -153,7 +153,7 @@ class LabeledSeqDataset(Dataset):
         seqs = resize(seqs, seq_len=self.padded_seq_len, end=self.end)
 
         if get_input_type(seqs) == "intervals":
-            seqs = filter_chrom_ends(seqs, genome=self.genome)
+            check_chrom_ends(seqs, genome=self.genome)
             self.intervals = seqs
             self.chroms = list(set(self.intervals.chrom))
         else:
@@ -605,8 +605,8 @@ class VariantDataset(Dataset):
         from grelu.variant import variants_to_intervals
 
         self.padded_seq_len = self.seq_len + (2 * self.max_seq_shift)
-        intervals = variants_to_intervals(variants, seq_len=self.padded_seq_len)
-        self.intervals = filter_chrom_ends(intervals, genome=self.genome)
+        self.intervals = variants_to_intervals(variants, seq_len=self.padded_seq_len)
+        check_chrom_ends(self.intervals, genome=self.genome)
         self.seqs = convert_input_type(self.intervals, "indices", genome=self.genome)
 
     def __len__(self) -> int:
@@ -713,8 +713,8 @@ class VariantMarginalizeDataset(Dataset):
         from grelu.variant import variants_to_intervals
 
         self.padded_seq_len = self.seq_len + (2 * self.max_seq_shift)
-        intervals = variants_to_intervals(variants, seq_len=self.padded_seq_len)
-        self.intervals = filter_chrom_ends(intervals, genome=self.genome)
+        self.intervals = variants_to_intervals(variants, seq_len=self.padded_seq_len)
+        check_chrom_ends(self.intervals, genome=self.genome)
         self.seqs = convert_input_type(self.intervals, "indices", genome=self.genome)
         self.n_seqs = self.seqs.shape[0]
 

--- a/src/grelu/data/dataset.py
+++ b/src/grelu/data/dataset.py
@@ -16,6 +16,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 
 from grelu.data.augment import Augmenter, _split_overall_idx
+from grelu.data.preprocess import filter_chrom_ends
 from grelu.data.utils import _check_multiclass, _create_task_data
 from grelu.sequence.format import (
     INDEX_TO_BASE_HASH,
@@ -152,6 +153,7 @@ class LabeledSeqDataset(Dataset):
         seqs = resize(seqs, seq_len=self.padded_seq_len, end=self.end)
 
         if get_input_type(seqs) == "intervals":
+            seqs = filter_chrom_ends(seqs, genome=self.genome)
             self.intervals = seqs
             self.chroms = list(set(self.intervals.chrom))
         else:
@@ -603,7 +605,8 @@ class VariantDataset(Dataset):
         from grelu.variant import variants_to_intervals
 
         self.padded_seq_len = self.seq_len + (2 * self.max_seq_shift)
-        self.intervals = variants_to_intervals(variants, seq_len=self.padded_seq_len)
+        intervals = variants_to_intervals(variants, seq_len=self.padded_seq_len)
+        self.intervals = filter_chrom_ends(intervals, genome=self.genome)
         self.seqs = convert_input_type(self.intervals, "indices", genome=self.genome)
 
     def __len__(self) -> int:
@@ -710,7 +713,8 @@ class VariantMarginalizeDataset(Dataset):
         from grelu.variant import variants_to_intervals
 
         self.padded_seq_len = self.seq_len + (2 * self.max_seq_shift)
-        self.intervals = variants_to_intervals(variants, seq_len=self.padded_seq_len)
+        intervals = variants_to_intervals(variants, seq_len=self.padded_seq_len)
+        self.intervals = filter_chrom_ends(intervals, genome=self.genome)
         self.seqs = convert_input_type(self.intervals, "indices", genome=self.genome)
         self.n_seqs = self.seqs.shape[0]
 

--- a/src/grelu/data/preprocess.py
+++ b/src/grelu/data/preprocess.py
@@ -33,14 +33,15 @@ def filter_intervals(
     Returns:
         Filtered intervals in the same format (if inplace = False)
     """
-    print("Keeping {} intervals".format(sum(keep)))
-    if isinstance(data, pd.DataFrame):
-        return data.drop(index=data.index[~keep], inplace=inplace)
-    elif isinstance(data, AnnData):
-        if inplace:
-            data._inplace_subset_var(index=data.var_names[keep])
-        else:
-            return data[:, keep]
+    if sum(keep) < data.shape[0]:
+        print("Keeping {} of {} intervals".format(sum(keep), data.shape[0]))
+        if isinstance(data, pd.DataFrame):
+            return data.drop(index=data.index[~keep], inplace=inplace)
+        elif isinstance(data, AnnData):
+            if inplace:
+                data._inplace_subset_var(index=data.var_names[keep])
+            else:
+                return data[:, keep]
 
 
 def filter_obs(

--- a/src/grelu/data/preprocess.py
+++ b/src/grelu/data/preprocess.py
@@ -34,22 +34,14 @@ def filter_intervals(
     Returns:
         Filtered intervals in the same format (if inplace = False)
     """
-
+    print("Keeping {} intervals".format(sum(keep)))
     if isinstance(data, pd.DataFrame):
-        if sum(keep) < data.shape[0]:
-            print("Keeping {} of {} intervals".format(sum(keep), data.shape[0]))
-            return data.drop(index=data.index[~keep], inplace=inplace)
-        else:
-            return data
+        return data.drop(index=data.index[~keep], inplace=inplace)
     elif isinstance(data, AnnData):
-        if sum(keep) < data.shape[1]:
-            print("Keeping {} of {} intervals".format(sum(keep), data.shape[1]))
-            if inplace:
-                data._inplace_subset_var(index=data.var_names[keep])
-            else:
-                return data[:, keep]
+        if inplace:
+            data._inplace_subset_var(index=data.var_names[keep])
         else:
-            return data
+            return data[:, keep]
 
 
 def filter_obs(


### PR DESCRIPTION
In `LabeledSeqDataset`, we add padding at the end of intervals to load extra bases for data augmentation by shift/jittering. Similarly in `VariantDataset`, we generate intervals surrounding the variant. In both these cases, the extended/generated intervals may end up extending beyond the chromosome which will result in an error when we try to read sequences.

This PR introduces the following changes:
1. adds a function `check_chrom_ends` which raises an error if any intervals exceed the chromosome ends, and prints the relevant intervals. 
2. Added a test for this function
3. Added this function to the dataset classes. 

Addresses #54 