### PR TITLE
Make model checkpoints more informative (this time without logging the extra info)

### DIFF
--- a/src/grelu/data/dataset.py
+++ b/src/grelu/data/dataset.py
@@ -155,15 +155,11 @@ class LabeledSeqDataset(Dataset):
         self.predict = False
 
     def _load_seqs(self, seqs: Union[str, Sequence, pd.DataFrame, np.ndarray]) -> None:
-        seqs = resize(seqs, seq_len=self.padded_seq_len, end=self.end)
-
+        seqs = resize(seqs, seq_len=self.seq_len, end=self.end)
+        self.intervals = seqs if get_input_type(seqs) == "intervals" else None
+        seqs = resize(seqs, seq_len=self.padded_seq_len)
         if get_input_type(seqs) == "intervals":
             check_chrom_ends(seqs, genome=self.genome)
-            self.intervals = seqs
-            self.chroms = list(set(self.intervals.chrom))
-        else:
-            self.intervals = None
-            self.chroms = None
 
         self.seqs = convert_input_type(seqs, "indices", genome=self.genome)
 
@@ -488,12 +484,13 @@ class SeqDataset(Dataset):
         self.end = end
         self.genome = genome
 
-        # Calculate sequence length and augmentation
-        self.seq_len = seq_len or max(get_lengths(seqs))
-
         # Save augmentation params
         self.rc = rc
         self.max_seq_shift = max_seq_shift
+
+        # Calculate sequence length and augmentation
+        self.seq_len = seq_len or max(get_lengths(seqs))
+        self.padded_seq_len = self.seq_len + (2 * self.max_seq_shift)
 
         # Ingest sequences
         self._load_seqs(seqs)
@@ -511,11 +508,11 @@ class SeqDataset(Dataset):
         self.n_alleles = 1
 
     def _load_seqs(self, seqs: Union[str, Sequence, pd.DataFrame, np.ndarray]) -> None:
-        padded_seq_len = self.seq_len + (2 * self.max_seq_shift)
-        seqs = resize(seqs, seq_len=padded_seq_len, end=self.end)
+        seqs = resize(seqs, seq_len=self.seq_len, end=self.end)
+        self.intervals = seqs if get_input_type(seqs) == "intervals" else None
+        seqs = resize(seqs, seq_len=self.padded_seq_len)
         if get_input_type(seqs) == "intervals":
-            self.intervals = seqs
-            self.chroms = np.unique(seqs.chrom)
+            check_chrom_ends(seqs, genome=self.genome)
         self.seqs = convert_input_type(seqs, "indices", genome=self.genome)
 
     def __len__(self) -> int:
@@ -609,10 +606,12 @@ class VariantDataset(Dataset):
     def _load_seqs(self, variants: pd.DataFrame) -> None:
         from grelu.variant import variants_to_intervals
 
+        self.intervals = variants_to_intervals(variants, seq_len=self.seq_len)
+
         self.padded_seq_len = self.seq_len + (2 * self.max_seq_shift)
-        self.intervals = variants_to_intervals(variants, seq_len=self.padded_seq_len)
-        check_chrom_ends(self.intervals, genome=self.genome)
-        self.seqs = convert_input_type(self.intervals, "indices", genome=self.genome)
+        seqs = resize(self.intervals, seq_len=self.padded_seq_len)
+        check_chrom_ends(seqs, genome=self.genome)
+        self.seqs = convert_input_type(seqs, "indices", genome=self.genome)
 
     def __len__(self) -> int:
         return self.n_seqs * self.n_augmented * 2
@@ -717,10 +716,12 @@ class VariantMarginalizeDataset(Dataset):
         """
         from grelu.variant import variants_to_intervals
 
+        self.intervals = variants_to_intervals(variants, seq_len=self.seq_len)
+
         self.padded_seq_len = self.seq_len + (2 * self.max_seq_shift)
-        self.intervals = variants_to_intervals(variants, seq_len=self.padded_seq_len)
-        check_chrom_ends(self.intervals, genome=self.genome)
-        self.seqs = convert_input_type(self.intervals, "indices", genome=self.genome)
+        seqs = resize(self.intervals, self.padded_seq_len)
+        check_chrom_ends(seqs, genome=self.genome)
+        self.seqs = convert_input_type(seqs, "indices", genome=self.genome)
         self.n_seqs = self.seqs.shape[0]
 
     def __update__(self, idx: int) -> None:

--- a/src/grelu/lightning/__init__.py
+++ b/src/grelu/lightning/__init__.py
@@ -64,16 +64,12 @@ class LightningModel(pl.LightningModule):
     Args:
         model_params: Dictionary of parameters specifying model architecture
         train_params: Dictionary specifying training parameters
-        data_params: Dictionary specifying parameters of the training data.
-            This is empty by default and will be filled at the time of
-            training.
     """
 
     def __init__(
         self,
         model_params: dict,
         train_params: dict = {},
-        data_params: dict = {},
     ) -> None:
         super().__init__()
 
@@ -89,7 +85,8 @@ class LightningModel(pl.LightningModule):
         # Save params
         self.model_params = model_params
         self.train_params = train_params
-        self.data_params = data_params
+        self.data_params = dict()
+        self.performance = dict()
 
         # Build model
         self.build_model()
@@ -356,6 +353,9 @@ class LightningModel(pl.LightningModule):
 
         self.val_metrics.reset()
         self.val_losses = []
+        self.performance["val"] = {
+            k: v.detach().cpu().numpy() for k, v in val_metrics.items()
+        }
 
     def test_step(self, batch: Tensor, batch_idx: int) -> Tensor:
         """
@@ -374,13 +374,16 @@ class LightningModel(pl.LightningModule):
         """
         Calculate metrics for entire test set
         """
-        self.computed_test_metrics = self.test_metrics.compute()
-        self.log_dict({k: v.mean() for k, v in self.computed_test_metrics.items()})
+        test_metrics = self.test_metrics.compute()
+        self.log_dict({k: v.mean() for k, v in test_metrics.items()})
         losses = torch.stack(self.test_losses)
         self.log("test_loss", torch.mean(losses))
 
         self.test_metrics.reset()
         self.test_losses = []
+        self.performance["test"] = {
+            k: v.detach().cpu().numpy() for k, v in test_metrics.items()
+        }
 
     def configure_optimizers(self) -> None:
         """
@@ -571,11 +574,14 @@ class LightningModel(pl.LightningModule):
             names="name"
         ).to_dict(orient="list")
 
+        self.data_params["train"] = {}
+        self.data_params["val"] = {}
+
         for attr, value in self._get_dataset_attrs(train_dataset):
-            self.data_params["train_" + attr] = value
+            self.data_params["train"][attr] = value
 
         for attr, value in self._get_dataset_attrs(val_dataset):
-            self.data_params["val_" + attr] = value
+            self.data_params["val"][attr] = value
 
         # Add software params
         import grelu
@@ -599,13 +605,14 @@ class LightningModel(pl.LightningModule):
             if not attr.startswith("_") and not attr.isupper():
                 value = getattr(dataset, attr)
                 if (
-                    (attr == "chroms")
-                    or (isinstance(value, str))
+                    (isinstance(value, str))
                     or (isinstance(value, int))
                     or (isinstance(value, float))
                     or (value is None)
                 ):
                     yield attr, value
+                elif attr == "intervals":
+                    yield attr, value.to_dict(orient="list")
 
     def change_head(
         self,
@@ -669,7 +676,12 @@ class LightningModel(pl.LightningModule):
         return self.train_on_dataset(train_dataset, val_dataset)
 
     def on_save_checkpoint(self, checkpoint: dict) -> None:
-        checkpoint["hyper_parameters"]["data_params"] = self.data_params
+        checkpoint["data_params"] = self.data_params
+        checkpoint["performance"] = self.performance
+
+    def on_load_checkpoint(self, checkpoint: dict) -> None:
+        self.data_params = checkpoint["data_params"]
+        self.performance = checkpoint["performance"]
 
     def predict_on_seqs(
         self,
@@ -809,6 +821,7 @@ class LightningModel(pl.LightningModule):
         num_workers: int = 1,
         batch_size: int = 256,
         precision: Optional[str] = None,
+        write_path: Optional[str] = None,
     ):
         """
         Run test loop for a dataset
@@ -819,6 +832,8 @@ class LightningModel(pl.LightningModule):
             num_workers: Number of workers for data loader
             batch_size: Batch size for data loader
             precision: Precision of the trainer e.g. '32' or 'bf16-mixed'.
+            write_path: Path to write a new model checkpoint containing
+                test data parameters and performance.
 
         Returns:
             Dataframe containing all calculated metrics on the test set.
@@ -838,12 +853,17 @@ class LightningModel(pl.LightningModule):
         )
         self.test_metrics.reset()
         trainer.test(model=self, dataloaders=dataloader, verbose=True)
-
-        metric_dict = {
-            k: v.detach().cpu().numpy() for k, v in self.computed_test_metrics.items()
-        }
         self.test_metrics.reset()
-        return pd.DataFrame(metric_dict, index=self.data_params["tasks"]["name"])
+
+        self.data_params["test"] = {}
+        for attr, value in self._get_dataset_attrs(dataset):
+            self.data_params["test"][attr] = value
+
+        if write_path is not None:
+            trainer.save_checkpoint(write_path)
+        return pd.DataFrame(
+            self.performance["test"], index=self.data_params["tasks"]["name"]
+        )
 
     def embed_on_dataset(
         self,
@@ -956,7 +976,7 @@ class LightningModel(pl.LightningModule):
 
         """
         output_bin = (input_coord - start_pos) / self.data_params[
-            "train_bin_size"
+            "train"["bin_size"
         ] - self.model_params["crop_len"]
         return int(np.floor(output_bin))
 
@@ -981,12 +1001,12 @@ class LightningModel(pl.LightningModule):
 
         """
         start = (output_bin + self.model_params["crop_len"]) * self.data_params[
-            "train_bin_size"
+            "train"]["bin_size"
         ]
         if return_pos == "start":
             return start + start_pos
         elif return_pos == "end":
-            return start + self.data_params["train_bin_size"] + start_pos
+            return start + self.data_params["train"]["bin_size"] + start_pos
         else:
             raise NotImplementedError
 
@@ -1007,7 +1027,7 @@ class LightningModel(pl.LightningModule):
             to the model output from each input interval.
         """
         output_intervals = intervals.copy()
-        crop_coords = self.model_params["crop_len"] * self.data_params["train_bin_size"]
+        crop_coords = self.model_params["crop_len"] * self.data_params["train"["bin_size"]
         output_intervals["start"] = intervals.start + crop_coords
         output_intervals["end"] = intervals.end - crop_coords
         return output_intervals

--- a/src/grelu/lightning/__init__.py
+++ b/src/grelu/lightning/__init__.py
@@ -975,9 +975,9 @@ class LightningModel(pl.LightningModule):
             Index of the output bin containing the given position.
 
         """
-        output_bin = (input_coord - start_pos) / self.data_params[
-            "train"["bin_size"
-        ] - self.model_params["crop_len"]
+        output_bin = (
+            (input_coord - start_pos) / self.data_params["train"]["bin_size"]
+        ) - self.model_params["crop_len"]
         return int(np.floor(output_bin))
 
     def output_bin_to_input_coord(
@@ -1001,8 +1001,8 @@ class LightningModel(pl.LightningModule):
 
         """
         start = (output_bin + self.model_params["crop_len"]) * self.data_params[
-            "train"]["bin_size"
-        ]
+            "train"
+        ]["bin_size"]
         if return_pos == "start":
             return start + start_pos
         elif return_pos == "end":
@@ -1027,7 +1027,9 @@ class LightningModel(pl.LightningModule):
             to the model output from each input interval.
         """
         output_intervals = intervals.copy()
-        crop_coords = self.model_params["crop_len"] * self.data_params["train"["bin_size"]
+        crop_coords = (
+            self.model_params["crop_len"] * self.data_params["train"]["bin_size"]
+        )
         output_intervals["start"] = intervals.start + crop_coords
         output_intervals["end"] = intervals.end - crop_coords
         return output_intervals

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -17,6 +17,7 @@ from grelu.data.dataset import (
     VariantMarginalizeDataset,
 )
 from grelu.sequence.format import convert_input_type
+from grelu.variant import variants_to_intervals
 
 cwd = os.path.realpath(os.path.dirname(__file__))
 
@@ -47,6 +48,7 @@ def test_dfseqdataset_seqs_no_aug():
         and (ds.labels.shape == (2, 2, 1))
         and (len(ds) == 2)
         and not (ds.predict)
+        and (ds.intervals is None)
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -94,6 +96,7 @@ def test_dfseqdataset_seqs_aug():
         and ds.labels.shape == (2, 1, 1)
         and (len(ds) == 4)
         and (not ds.predict)
+        and (ds.intervals is None)
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -136,6 +139,7 @@ def test_dfseqdataset_seqs_multiclass():
         and ds.labels.shape == (2, 2, 1)
         and (len(ds) == 4)
         and (not ds.predict)
+        and (ds.intervals is None)
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -179,9 +183,9 @@ def test_dfseqdataset_intervals_no_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 1)
         and (np.all(ds.tasks.index == ["label1"]))
-        and (ds.chroms == ["chr1"])
         and (len(ds) == 2)
         and (not ds.predict)
+        and (ds.intervals.equals(interval_df.iloc[:, :3]))
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -204,9 +208,9 @@ def test_dfseqdataset_intervals_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 2)
         and (np.all(ds.tasks.index == ["label1"]))
-        and (ds.chroms == ["chr1"])
         and (len(ds) == 4)
         and (not ds.predict)
+        and (ds.intervals.equals(interval_df.iloc[:, :3]))
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -230,9 +234,9 @@ def test_dfseqdataset_intervals_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 3)
         and (np.all(ds.tasks.index == ["label1", "label2"]))
-        and (ds.chroms == ["chr1"])
         and (len(ds) == 6)
         and (not ds.predict)
+        and (ds.intervals.equals(interval_df.iloc[:, :3]))
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -276,8 +280,8 @@ def test_dfseqdataset_intervals_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 6)
         and (np.all(ds.tasks.index == ["label1"]))
-        and (ds.chroms == ["chr1"])
         and (not ds.predict)
+        and (ds.intervals.equals(interval_df.iloc[:, :3]))
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -335,9 +339,9 @@ def test_dfseqdataset_intervals_multiclass():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 1)
         and (np.all(ds.tasks.index == ["T1", "T2"]))
-        and (ds.chroms == ["chr1"])
         and (len(ds) == 2)
         and (not ds.predict)
+        and (ds.intervals.equals(interval_df.iloc[:, :3]))
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -370,8 +374,8 @@ def test_anndata_dataset_no_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 1)
         and (np.all(ds.tasks.index == ["label1", "label2"]))
-        and (ds.chroms == ["chr1"])
         and (not ds.predict)
+        and (ds.intervals.equals(ad.var))
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -392,8 +396,8 @@ def test_anndata_dataset_no_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 1)
         and (np.all(ds.tasks.index == ["label1", "label2"]))
-        and (ds.chroms == ["chr1"])
         and (len(ds) == 2)
+        and (ds.intervals.equals(ad.var))
     )
     xs = [ds[i] for i in range(len(ds))]
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -412,8 +416,8 @@ def test_anndata_dataset_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 2)
         and (np.all(ds.tasks.index == ["label1", "label2"]))
-        and (ds.chroms == ["chr1"])
         and (not ds.predict)
+        and (ds.intervals.equals(ad.var))
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -433,8 +437,8 @@ def test_anndata_dataset_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 3)
         and (np.all(ds.tasks.index == ["label1", "label2"]))
-        and (ds.chroms == ["chr1"])
         and (len(ds) == 6)
+        and (ds.intervals.equals(ad.var))
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -456,7 +460,7 @@ def test_anndata_dataset_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 6)
         and (np.all(ds.tasks.index == ["label1", "label2"]))
-        and (ds.chroms == ["chr1"])
+        and (ds.intervals.equals(ad.var))
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -517,8 +521,8 @@ def test_bigwig_dataset_no_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 1)
         and (np.all(ds.tasks.index == ["test"]))
-        and (ds.chroms == ["chr1"])
         and (len(ds) == 2)
+        and (ds.intervals.equals(bw_intervals))
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     ys = torch.stack(ys)
@@ -544,9 +548,9 @@ def test_bigwig_dataset_no_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 1)
         and (np.all(ds.tasks.index == ["test"]))
-        and (ds.chroms == ["chr1"])
         and (len(ds) == 2)
         and (ds.bin_size == 2)
+        and (ds.intervals.equals(bw_intervals))
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     ys = torch.stack(ys)
@@ -575,9 +579,9 @@ def test_bigwig_dataset_no_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 1)
         and (np.all(ds.tasks.index == ["test"]))
-        and (ds.chroms == ["chr1"])
         and (len(ds) == 2)
         and (ds.bin_size == 2)
+        and (ds.intervals.equals(bw_intervals))
     )
     xs, ys = list(zip(*[ds[i] for i in range(len(ds))]))
     ys = torch.stack(ys)
@@ -597,6 +601,7 @@ def test_unlabeled_dataset_no_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 1)
         and (len(ds) == 2)
+        and (ds.intervals.equals(interval_df.iloc[:, :3]))
     )
     xs = [ds[i] for i in range(len(ds))]
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -613,6 +618,7 @@ def test_unlabeled_dataset_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 2)
         and (len(ds) == 4)
+        and (ds.intervals.equals(interval_df.iloc[:, :3]))
     )
     xs = [ds[i] for i in range(len(ds))]
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -627,6 +633,7 @@ def test_unlabeled_dataset_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 3)
         and (len(ds) == 6)
+        and (ds.intervals.equals(interval_df.iloc[:, :3]))
     )
     xs = [ds[i] for i in range(len(ds))]
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -641,6 +648,7 @@ def test_unlabeled_dataset_aug():
         and (ds.n_seqs == 2)
         and (ds.n_augmented == 6)
         and (len(ds) == 12)
+        and (ds.intervals.equals(interval_df.iloc[:, :3]))
     )
     xs = [ds[i] for i in range(len(ds))]
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -667,6 +675,7 @@ variants = pd.read_table(variant_file, usecols=(0, 1, 2)).iloc[:2, :]
 variants["ref"] = variants.variation.apply(lambda x: x.split(">")[0])
 variants["alt"] = variants.variation.apply(lambda x: x.split(">")[1].split(",")[0])
 variants = variants[["chrom", "pos", "ref", "alt"]]
+expected_intervals = variants_to_intervals(variants, seq_len=4)
 
 
 def test_variant_dataset_no_aug():
@@ -680,6 +689,7 @@ def test_variant_dataset_no_aug():
         and (ds.n_augmented == 1)
         and (ds.n_alleles == 2)
         and (len(ds) == 4)
+        and (ds.intervals.equals(expected_intervals))
     )
     xs = [ds[i] for i in range(len(ds))]
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -697,6 +707,7 @@ def test_variant_dataset_aug():
         and (ds.n_augmented == 2)
         and (ds.n_alleles == 2)
         and (len(ds) == 8)
+        and (ds.intervals.equals(expected_intervals))
     )
     xs = [ds[i] for i in range(len(ds))]
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -712,6 +723,7 @@ def test_variant_dataset_aug():
         and (ds.n_augmented == 3)
         and (ds.n_alleles == 2)
         and (len(ds) == 12)
+        and (ds.intervals.equals(expected_intervals))
     )
     xs = [ds[i] for i in range(len(ds))]
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -740,6 +752,7 @@ def test_variant_dataset_aug():
         and (ds.n_augmented == 6)
         and (ds.n_alleles == 2)
         and (len(ds) == 24)
+        and (ds.intervals.equals(expected_intervals))
     )
     xs = [ds[i] for i in range(len(ds))]
     xs = [convert_input_type(x, "strings") for x in xs]
@@ -799,6 +812,7 @@ def test_marginalize_dataset_variants():
     ds = VariantMarginalizeDataset(
         variants=variants, genome="hg38", seq_len=12, n_shuffles=2, seed=0
     )
+    expected_intervals = variants_to_intervals(variants, seq_len=12)
     assert (
         (ds.n_shuffles == 2)
         and (ds.seq_len == 12)
@@ -809,6 +823,7 @@ def test_marginalize_dataset_variants():
         and (ds.n_augmented == 2)
         and (np.allclose(ds.ref, np.array([[2], [2]])))
         and (np.allclose(ds.alt, np.array([[0], [0]])))
+        and (ds.intervals.equals(expected_intervals))
     )
     assert convert_input_type(ds.seqs, "strings") == ["CATACGTGAGGC", "AGGAGGCCAAAG"]
     xs = [convert_input_type(ds[i], "strings") for i in range(len(ds))]

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -28,7 +28,6 @@ model = LightningModel(
         "num_workers": 1,
         "devices": "cpu",
     },
-    data_params={},
 )
 
 weight = Tensor([[1, 2, 0, 0], [0, 0, -2, -1]]).unsqueeze(2)

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -35,7 +35,6 @@ def generate_model(
             "class_weights": class_weights,
             "pos_weight": pos_weight,
         },
-        data_params={},
     )
 
     if n_tasks == 1:

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -374,15 +374,15 @@ def test_lightning_model_ensemble():
 
 bin_model = generate_model(task="binary", loss="bce", n_tasks=2)
 bin_model.model_params["crop_len"] = 0
-bin_model.data_params["train"]["bin_size"] = 2
+bin_model.data_params["train"] = {"bin_size": 2}
 
 crop_model = generate_model(task="binary", loss="bce", n_tasks=2)
 crop_model.model_params["crop_len"] = 3
-crop_model.data_params["train"]["bin_size"] = 1
+crop_model.data_params["train"] = {"bin_size": 1}
 
 crop_bin_model = generate_model(task="binary", loss="bce", n_tasks=2)
 crop_bin_model.model_params["crop_len"] = 3
-crop_bin_model.data_params["train"]["bin_size"] = 2
+crop_bin_model.data_params["train"] = {"bin_size": 2}
 
 
 def test_input_coord_to_output_bin():


### PR DESCRIPTION
Redid the previous (reverted PR) except that now `self.data_params` and `self.performance` are stored as separate parameters in the checkpoint dictionary, instead of under `hyperparameters`. Hence, they are not logged.

The relevant change is here: https://github.com/Genentech/gReLU/pull/114/files#diff-18ad8745136e77d3b3cfe525f5f51a89f52489d7db61faeaf52deecbb249ad16L671