### PR TITLE
:lady_beetle: Replace `positional arguments` with `keyword arguments` to avoid misassignment of `blacklist` parameter

### DIFF
--- a/src/grelu/data/preprocess.py
+++ b/src/grelu/data/preprocess.py
@@ -532,7 +532,7 @@ def get_gc_matched_intervals(
     genome: str,
     binwidth: float = 0.1,
     chroms: str = "autosomes",
-    blacklist: Optional[str] = None,  # "hg38"  # <---- Please review
+    blacklist: Optional[str] = None
     seed: Optional[int] = None,
 ) -> pd.DataFrame:
     """

--- a/src/grelu/data/preprocess.py
+++ b/src/grelu/data/preprocess.py
@@ -532,7 +532,7 @@ def get_gc_matched_intervals(
     genome: str,
     binwidth: float = 0.1,
     chroms: str = "autosomes",
-    blacklist: Optional[str] = None
+    blacklist: Optional[str] = None,
     seed: Optional[int] = None,
 ) -> pd.DataFrame:
     """

--- a/src/grelu/data/preprocess.py
+++ b/src/grelu/data/preprocess.py
@@ -573,7 +573,7 @@ def get_gc_matched_intervals(
 
     print("Filtering blacklist")
     if blacklist is not None:
-        matched_loci = filter_blacklist(data=matched_loci, gnome=gnome, blacklist=blacklist)
+        matched_loci = filter_blacklist(data=matched_loci, genome=genome, blacklist=blacklist)
     return matched_loci
 
 

--- a/src/grelu/data/preprocess.py
+++ b/src/grelu/data/preprocess.py
@@ -573,7 +573,9 @@ def get_gc_matched_intervals(
 
     print("Filtering blacklist")
     if blacklist is not None:
-        matched_loci = filter_blacklist(data=matched_loci, genome=genome, blacklist=blacklist)
+        matched_loci = filter_blacklist(
+            data=matched_loci, genome=genome, blacklist=blacklist
+        )
     return matched_loci
 
 

--- a/src/grelu/data/preprocess.py
+++ b/src/grelu/data/preprocess.py
@@ -532,7 +532,7 @@ def get_gc_matched_intervals(
     genome: str,
     binwidth: float = 0.1,
     chroms: str = "autosomes",
-    blacklist: str = "hg38",
+    blacklist: Optional[str] = None, # "hg38"  # <---- Please review
     seed: Optional[int] = None,
 ) -> pd.DataFrame:
     """
@@ -573,7 +573,7 @@ def get_gc_matched_intervals(
 
     print("Filtering blacklist")
     if blacklist is not None:
-        matched_loci = filter_blacklist(matched_loci, blacklist)
+        matched_loci = filter_blacklist(data=matched_loci, gnome=gnome, blacklist=blacklist)
     return matched_loci
 
 


### PR DESCRIPTION
* Previously, the get_gc_matched_intervals(...) was invoking filter_blacklist(matched_loci, blacklist).
* Because of positional arguments, the function was used in the wrong way like this filter_blacklist(data = matched_loci, gnome = blacklisti)
* To repair the error, the keyword arguments were explicitly added
* I also took the liberty to change the `blacklist=None` in get_gc_matched_intervals(...) function to prevent accidentally passing blacklist = "hg38" in the fliter_blacklist function