### PR TITLE
Diagram visualization for the gReLU codebase

### DIFF
--- a/.codeboarding/Core & Resource Utilities.md
+++ b/.codeboarding/Core & Resource Utilities.md
@@ -1,0 +1,147 @@
+```mermaid
+graph LR
+    Utilities["Utilities"]
+    Variant_Analysis["Variant Analysis"]
+    Visualization["Visualization"]
+    Interpretation["Interpretation"]
+    Resource_Management["Resource Management"]
+    Models["Models"]
+    Lightning_Integration["Lightning Integration"]
+    Data_Loading_Augmentation["Data Loading & Augmentation"]
+    Transforms["Transforms"]
+    Data_Loading_Augmentation -- "provides data" --> Lightning_Integration
+    Lightning_Integration -- "predicts with" --> Models
+    Lightning_Integration -- "outputs to" --> Transforms
+    Data_Loading_Augmentation -- "preprocesses data for" --> Transforms
+    Models -- "loads from" --> Resource_Management
+    Lightning_Integration -- "utilizes resources from" --> Resource_Management
+    Transforms -- "accesses resources from" --> Resource_Management
+    Interpretation -- "processes data from" --> Data_Loading_Augmentation
+    Variant_Analysis -- "processes data from" --> Data_Loading_Augmentation
+    Interpretation -- "applies transformations from" --> Transforms
+    Variant_Analysis -- "uses" --> Utilities
+    Visualization -- "uses" --> Utilities
+    Interpretation -- "uses" --> Utilities
+    Lightning_Integration -- "uses" --> Utilities
+    Data_Loading_Augmentation -- "uses" --> Utilities
+    Transforms -- "uses" --> Utilities
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The system is designed for genomic sequence analysis, focusing on predicting and interpreting the effects of genetic variants. It encompasses modules for data loading and augmentation, deep learning model integration (including pre-trained models like Borzoi and Enformer), and various transformation utilities for both input sequences and model predictions/labels. The system also provides functionalities for visualizing results and interpreting model outputs, such as identifying important DNA regions. Resource management handles the retrieval of external assets like models and datasets, ensuring a streamlined workflow for genomic research.
+
+### Utilities
+This component provides a collection of general-purpose utility functions used across the gReLU project. These functions handle common operations such as aggregating values, comparing data, transforming data (e.g., log transformations), and converting various data types into lists. It acts as a foundational layer, offering reusable helper methods to other components.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/utils.py#L63-L93" target="_blank" rel="noopener noreferrer">`grelu.utils.get_compare_func` (63:93)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/utils.py#L128-L154" target="_blank" rel="noopener noreferrer">`grelu.utils.make_list` (128:154)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/utils.py#L29-L60" target="_blank" rel="noopener noreferrer">`grelu.utils.get_aggfunc` (29:60)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/utils.py#L96-L125" target="_blank" rel="noopener noreferrer">`grelu.utils.get_transform_func` (96:125)</a>
+
+
+### Variant Analysis
+The Variant Analysis component is responsible for processing and predicting the effects of genetic variants. It includes functionalities for filtering variants, converting them into genomic intervals, and performing predictions and marginalization experiments using trained models. This component leverages data loading capabilities and utility functions for its operations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/variant.py#L185-L275" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.variant:predict_variant_effects` (185:275)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/variant.py#L278-L397" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.variant:marginalize_variants` (278:397)</a>
+
+
+### Visualization
+This component focuses on generating various plots and visualizations to represent data and model predictions. It includes functions for plotting distributions, scatter plots, calibration curves, and attention matrices. It relies on utility functions to prepare data for plotting.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L20-L79" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.visualize:_collect_preds_and_labels` (20:79)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L82-L120" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.visualize:plot_distribution` (82:120)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L306-L357" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.visualize:add_highlights` (306:357)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L586-L700" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.visualize:plot_tracks` (586:700)</a>
+
+
+### Interpretation
+The Interpretation component provides methods to understand and score the importance of individual DNA bases or regions based on a trained model's predictions. This includes techniques like In Silico Mutagenesis (ISM) and attribution methods. It interacts with data loading and utility components to perform its analysis.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/score.py#L23-L122" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.score:ISM_predict` (23:122)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/motifs.py#L19-L71" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.motifs:motifs_to_strings` (19:71)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/motifs.py#L113-L214" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.motifs:scan_sequences` (113:214)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/motifs.py#L217-L251" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.motifs:score_sites` (217:251)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/simulate.py#L9-L87" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.simulate:marginalize_patterns` (9:87)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/simulate.py#L90-L178" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.simulate:marginalize_pattern_spacing` (90:178)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/simulate.py#L181-L259" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.simulate:shuffle_tiles` (181:259)</a>
+
+
+### Resource Management
+This component is responsible for managing and retrieving external resources and artifacts, such as pre-trained models and datasets. It interacts with external services (like Weights & Biases) to download and load necessary files for the application.
+
+
+**Related Classes/Methods**:
+
+- `gReLU.src.grelu.resources:get_artifact` (full file reference)
+- `gReLU.src.grelu.resources:load_model` (full file reference)
+- `gReLU.src.grelu.resources._check_wandb` (full file reference)
+- `gReLU.src.grelu.resources:get_dataset_by_model` (full file reference)
+- `gReLU.src.grelu.resources:get_model_by_dataset` (full file reference)
+
+
+### Models
+The Models component defines and encapsulates various deep learning model architectures, including pre-trained models like Borzoi and Enformer. It handles the initialization and loading of model weights, often relying on the Resource Management component to fetch pre-trained artifacts.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L567-L626" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.models.BorzoiPretrainedModel:__init__` (567:626)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L740-L790" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.models.EnformerPretrainedModel:__init__` (740:790)</a>
+
+
+### Lightning Integration
+This component integrates the deep learning models with PyTorch Lightning, providing functionalities for parsing devices, predicting on datasets, and managing task indices. It acts as an interface between the core model architectures and the training/prediction pipeline.
+
+
+**Related Classes/Methods**:
+
+- `gReLU.src.grelu.lightning.LightningModel:parse_devices` (full file reference)
+- `gReLU.src.grelu.lightning.LightningModel:predict_on_dataset` (full file reference)
+- `gReLU.src.grelu.lightning.LightningModel:get_task_idxs` (full file reference)
+
+
+### Data Loading & Augmentation
+This component is responsible for loading, preprocessing, and augmenting genomic sequence data and their associated labels. It defines various dataset classes (e.g., LabeledSeqDataset, VariantDataset) that handle different data formats and augmentation strategies, preparing the data for model input.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L73-L142" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.data.preprocess:filter_coverage` (73:142)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L72-L156" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.data.dataset.LabeledSeqDataset:__init__` (72:156)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L178-L197" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.data.dataset.LabeledSeqDataset:get_labels` (178:197)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L199-L228" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.data.dataset.LabeledSeqDataset:__getitem__` (199:228)</a>
+
+
+### Transforms
+This component provides various transformations applied to data, labels, and model predictions. It includes functionalities for aggregating prediction outputs, calculating specific metrics, clipping label values, and scoring patterns within genomic sequences. These transformations prepare data for model input, refine model outputs, or facilitate further analysis.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/transforms/prediction_transforms.py#L39-L92" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.transforms.prediction_transforms.Aggregate:__init__` (39:92)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/transforms/prediction_transforms.py#L184-L220" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.transforms.prediction_transforms.Specificity:__init__` (184:220)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/transforms/prediction_transforms.py#L231-L241" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.transforms.prediction_transforms.Specificity:forward` (231:241)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/transforms/prediction_transforms.py#L243-L250" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.transforms.prediction_transforms.Specificity:compute` (243:250)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/transforms/label_transforms.py#L25-L33" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.transforms.label_transforms.LabelTransform:__init__` (25:33)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/transforms/label_transforms.py#L51-L52" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.transforms.label_transforms.LabelTransform:__call__` (51:52)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/transforms/seq_transforms.py#L54-L55" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.transforms.seq_transforms.PatternScore:__call__` (54:55)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data Management & Preparation.md
+++ b/.codeboarding/Data Management & Preparation.md
@@ -1,0 +1,176 @@
+```mermaid
+graph LR
+    SequenceCore["SequenceCore"]
+    DataLoader["DataLoader"]
+    DataProcessor["DataProcessor"]
+    DatasetManager["DatasetManager"]
+    SequenceMutator["SequenceMutator"]
+    VariantAnalyzer["VariantAnalyzer"]
+    DataLoader -- "Supplies raw genomic data for preprocessing." --> DataProcessor
+    DataLoader -- "Loads genomic data into dataset structures." --> DatasetManager
+    SequenceCore -- "Provides sequence formatting and utility functions for data loading." --> DataLoader
+    SequenceCore -- "Offers sequence format validation and manipulation utilities for data preprocessing." --> DataProcessor
+    SequenceCore -- "Converts and validates sequence data formats for dataset creation and handling." --> DatasetManager
+    SequenceCore -- "Determines input type and provides utilities for mutation operations." --> SequenceMutator
+    SequenceCore -- "Converts genomic intervals to sequences and provides format utilities for variant analysis." --> VariantAnalyzer
+    DataProcessor -- "Applies preprocessing and augmentation transformations to data used by datasets." --> DatasetManager
+    SequenceMutator -- "Provides mutation functionalities for data augmentation." --> DataProcessor
+    SequenceMutator -- "Enables mutation operations within specialized datasets (e.g., VariantDataset)." --> DatasetManager
+    VariantAnalyzer -- "Processes variant information and integrates it into variant-specific dataset constructions." --> DatasetManager
+    VariantAnalyzer -- "Utilizes mutation operations for variant effect prediction and analysis." --> SequenceMutator
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Data Management & Preparation component is responsible for handling all aspects of biological sequence data within the gReLU project. This includes reading raw sequence data from various file formats, performing basic manipulations, augmenting data for increased diversity, processing genetic variants, and providing abstract dataset interfaces that can be consumed by models. It ensures data consistency, prepares sequences for downstream tasks, and facilitates specialized analyses like variant effect prediction and motif scanning.
+
+### SequenceCore
+Provides fundamental functionalities for handling DNA sequences, including format validation (intervals, strings, indices, one-hot), conversion between these formats, and utility functions like padding, trimming, reversing complements, and shuffling. It ensures data consistency and prepares sequences for various downstream tasks.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L32-L52" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:check_intervals` (32:52)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L55-L66" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:check_string_dna` (55:66)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L69-L88" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:check_indices` (69:88)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L91-L110" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:check_one_hot` (91:110)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L113-L157" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:get_input_type` (113:157)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L160-L221" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:intervals_to_strings` (160:221)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L224-L260" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:strings_to_indices` (224:260)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L263-L294" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:indices_to_one_hot` (263:294)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L297-L320" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:strings_to_one_hot` (297:320)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L323-L339" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:one_hot_to_indices` (323:339)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L342-L353" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:one_hot_to_strings` (342:353)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L356-L372" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:indices_to_strings` (356:372)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L375-L440" target="_blank" rel="noopener noreferrer">`grelu.sequence.format:convert_input_type` (375:440)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L24-L66" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils:get_lengths` (24:66)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L69-L83" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils:check_equal_lengths` (69:83)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L86-L103" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils:get_unique_length` (86:103)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L106-L189" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils:pad` (106:189)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L192-L260" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils:trim` (192:260)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L263-L332" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils:resize` (263:332)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L335-L372" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils:reverse_complement` (335:372)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L375-L415" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils:dinuc_shuffle` (375:415)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L418-L444" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils:generate_random_sequences` (418:444)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/metrics.py#L14-L62" target="_blank" rel="noopener noreferrer">`grelu.sequence.metrics:gc` (14:62)</a>
+
+
+### DataLoader
+Responsible for reading and managing various types of genomic and sequence data from different file formats (FASTA, BigWig, BED) and integrating with genome information. It provides the foundational data structures for other components to operate on.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/io/fasta.py#L29-L50" target="_blank" rel="noopener noreferrer">`grelu.io.fasta:read_fasta` (29:50)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/io/fasta.py#L11-L26" target="_blank" rel="noopener noreferrer">`grelu.io.fasta:check_fasta` (11:26)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/io/genome.py#L13-L33" target="_blank" rel="noopener noreferrer">`grelu.io.genome:read_sizes` (13:33)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/io/genome.py#L36-L50" target="_blank" rel="noopener noreferrer">`grelu.io.genome:get_genome` (36:50)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/io/bigwig.py#L31-L99" target="_blank" rel="noopener noreferrer">`grelu.io.bigwig:read_bigwig` (31:99)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/io/bigwig.py#L13-L28" target="_blank" rel="noopener noreferrer">`grelu.io.bigwig:check_bigwig` (13:28)</a>
+- `grelu.io.bed` (full file reference)
+
+
+### DataProcessor
+Handles the preparation and enhancement of raw sequence data. It includes functionalities for filtering sequences based on various criteria (coverage, chromosomes, blacklist, overlaps) and augmenting data through random mutations or reverse complementation to increase dataset diversity.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L73-L142" target="_blank" rel="noopener noreferrer">`grelu.data.preprocess:filter_coverage` (73:142)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L145-L167" target="_blank" rel="noopener noreferrer">`grelu.data.preprocess:filter_cells` (145:167)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L172-L202" target="_blank" rel="noopener noreferrer">`grelu.data.preprocess:filter_random` (172:202)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L205-L242" target="_blank" rel="noopener noreferrer">`grelu.data.preprocess:filter_chromosomes` (205:242)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L274-L334" target="_blank" rel="noopener noreferrer">`grelu.data.preprocess:filter_overlapping` (274:334)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L337-L377" target="_blank" rel="noopener noreferrer">`grelu.data.preprocess:filter_blacklist` (337:377)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L380-L422" target="_blank" rel="noopener noreferrer">`grelu.data.preprocess:check_chrom_ends` (380:422)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L425-L464" target="_blank" rel="noopener noreferrer">`grelu.data.preprocess:filter_chrom_ends` (425:464)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L467-L527" target="_blank" rel="noopener noreferrer">`grelu.data.preprocess:split` (467:527)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L530-L579" target="_blank" rel="noopener noreferrer">`grelu.data.preprocess:get_gc_matched_intervals` (530:579)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L706-L776" target="_blank" rel="noopener noreferrer">`grelu.data.preprocess:make_insertion_bigwig` (706:776)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/utils.py#L36-L65" target="_blank" rel="noopener noreferrer">`grelu.data.utils:get_chromosomes` (36:65)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/utils.py#L68-L94" target="_blank" rel="noopener noreferrer">`grelu.data.utils:_tile_positions` (68:94)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/augment.py#L65-L77" target="_blank" rel="noopener noreferrer">`grelu.data.augment:rc_seq` (65:77)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/augment.py#L80-L92" target="_blank" rel="noopener noreferrer">`grelu.data.augment:rc_label` (80:92)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/augment.py#L116-L166" target="_blank" rel="noopener noreferrer">`grelu.data.augment.Augmenter:__init__` (116:166)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/augment.py#L188-L245" target="_blank" rel="noopener noreferrer">`grelu.data.augment.Augmenter:__call__` (188:245)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/augment.py#L34-L35" target="_blank" rel="noopener noreferrer">`grelu.data.augment._get_multipliers` (34:35)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/augment.py#L38-L47" target="_blank" rel="noopener noreferrer">`grelu.data.augment._split_overall_idx` (38:47)</a>
+
+
+### DatasetManager
+Defines and manages various specialized dataset classes for different types of sequence analysis tasks. These datasets handle the loading, resizing, and batching of sequences, often incorporating data augmentation and specific logic for variants, motifs, or marginalization experiments.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L72-L156" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.LabeledSeqDataset:__init__` (72:156)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L158-L165" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.LabeledSeqDataset:_load_seqs` (158:165)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L167-L170" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.LabeledSeqDataset:_load_tasks` (167:170)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L172-L173" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.LabeledSeqDataset:_load_labels` (172:173)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L199-L228" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.LabeledSeqDataset:__getitem__` (199:228)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L252-L300" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.DFSeqDataset:__init__` (252:300)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L321-L366" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.AnnDataSeqDataset:__init__` (321:366)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L397-L438" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.BigWigSeqDataset:__init__` (397:438)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L440-L449" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.BigWigSeqDataset:_load_labels` (440:449)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L471-L509" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.SeqDataset:__init__` (471:509)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L511-L517" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.SeqDataset:_load_seqs` (511:517)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L522-L530" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.SeqDataset:__getitem__` (522:530)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L548-L582" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.VariantDataset:__init__` (548:582)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L584-L586" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.VariantDataset:_load_alleles` (584:586)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L588-L596" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.VariantDataset:_load_seqs` (588:596)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L601-L622" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.VariantDataset:__getitem__` (601:622)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L645-L685" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.VariantMarginalizeDataset:__init__` (645:685)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L687-L693" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.VariantMarginalizeDataset:_load_alleles` (687:693)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L695-L707" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.VariantMarginalizeDataset:_load_seqs` (695:707)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L709-L720" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.VariantMarginalizeDataset:__update__` (709:720)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L725-L749" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.VariantMarginalizeDataset:__getitem__` (725:749)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L771-L811" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.PatternMarginalizeDataset:__init__` (771:811)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L813-L815" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.PatternMarginalizeDataset:_load_alleles` (813:815)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L817-L828" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.PatternMarginalizeDataset:_load_seqs` (817:828)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L830-L841" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.PatternMarginalizeDataset:__update__` (830:841)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L846-L866" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.PatternMarginalizeDataset:__getitem__` (846:866)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L883-L904" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.ISMDataset:__init__` (883:904)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L906-L909" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.ISMDataset:_load_seqs` (906:909)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L914-L938" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.ISMDataset:__getitem__` (914:938)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L955-L983" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.MotifScanDataset:__init__` (955:983)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L985-L988" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.MotifScanDataset:_load_seqs` (985:988)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L993-L1000" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.MotifScanDataset:__getitem__` (993:1000)</a>
+- `grelu.data.dataset.SpacingMarginalizeDataset:__init__` (full file reference)
+- `grelu.data.dataset.SpacingMarginalizeDataset:_load_seqs` (full file reference)
+- `grelu.data.dataset.SpacingMarginalizeDataset:_load_patterns` (full file reference)
+- `grelu.data.dataset.SpacingMarginalizeDataset:__update__` (full file reference)
+- `grelu.data.dataset.SpacingMarginalizeDataset:__getitem__` (full file reference)
+- `grelu.data.dataset.TilingShuffleDataset:__init__` (full file reference)
+- `grelu.data.dataset.TilingShuffleDataset:_load_seqs` (full file reference)
+- `grelu.data.dataset.TilingShuffleDataset:__getitem__` (full file reference)
+
+
+### SequenceMutator
+Provides core functionalities for modifying DNA sequences. It includes methods for general mutation, insertion, deletion, and random mutation, which are crucial for variant analysis, sequence design, and data augmentation.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/mutate.py#L12-L57" target="_blank" rel="noopener noreferrer">`grelu.sequence.mutate:mutate` (12:57)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/mutate.py#L60-L114" target="_blank" rel="noopener noreferrer">`grelu.sequence.mutate:insert` (60:114)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/mutate.py#L117-L167" target="_blank" rel="noopener noreferrer">`grelu.sequence.mutate:delete` (117:167)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/mutate.py#L170-L224" target="_blank" rel="noopener noreferrer">`grelu.sequence.mutate:random_mutate` (170:224)</a>
+
+
+### VariantAnalyzer
+Focuses on functionalities related to genetic variants. It includes methods for converting variants to sequences, checking references, predicting variant effects, and marginalizing variants for analysis.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/variant.py#L104-L139" target="_blank" rel="noopener noreferrer">`grelu.variant:variant_to_seqs` (104:139)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/variant.py#L142-L182" target="_blank" rel="noopener noreferrer">`grelu.variant:check_reference` (142:182)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/variant.py#L185-L275" target="_blank" rel="noopener noreferrer">`grelu.variant:predict_variant_effects` (185:275)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/variant.py#L278-L397" target="_blank" rel="noopener noreferrer">`grelu.variant:marginalize_variants` (278:397)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/variant.py#L74-L101" target="_blank" rel="noopener noreferrer">`grelu.variant:variants_to_intervals` (74:101)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Model Analysis & Visualization.md
+++ b/.codeboarding/Model Analysis & Visualization.md
@@ -1,0 +1,198 @@
+```mermaid
+graph LR
+    Modisco_Interpretation["Modisco Interpretation"]
+    Motif_Analysis["Motif Analysis"]
+    Attribution_Scoring["Attribution Scoring"]
+    Simulation_Experiments["Simulation Experiments"]
+    Sequence_Utilities["Sequence Utilities"]
+    Data_Handling["Data Handling"]
+    General_Utilities["General Utilities"]
+    Motif_I_O["Motif I/O"]
+    Visualization_Core["Visualization Core"]
+    Prediction_Visualization["Prediction Visualization"]
+    Model_Core["Model Core"]
+    Sequence_Metrics["Sequence Metrics"]
+    Genome_I_O["Genome I/O"]
+    Modisco_Interpretation -- "uses" --> Sequence_Utilities
+    Modisco_Interpretation -- "obtains attributions from" --> Attribution_Scoring
+    Modisco_Interpretation -- "performs motif comparison via" --> Motif_Analysis
+    Modisco_Interpretation -- "creates datasets with" --> Data_Handling
+    Modisco_Interpretation -- "reads motif data from" --> Motif_I_O
+    Motif_Analysis -- "reads motif data from" --> Motif_I_O
+    Motif_Analysis -- "utilizes" --> General_Utilities
+    Motif_Analysis -- "uses" --> Sequence_Utilities
+    Attribution_Scoring -- "processes sequences using" --> Sequence_Utilities
+    Attribution_Scoring -- "creates datasets with" --> Data_Handling
+    Attribution_Scoring -- "interacts with" --> Model_Core
+    Attribution_Scoring -- "utilizes" --> General_Utilities
+    Simulation_Experiments -- "generates datasets with" --> Data_Handling
+    Simulation_Experiments -- "applies comparison functions from" --> General_Utilities
+    Sequence_Utilities -- "used by" --> Modisco_Interpretation
+    Sequence_Utilities -- "used by" --> Motif_Analysis
+    Sequence_Utilities -- "used by" --> Attribution_Scoring
+    Sequence_Utilities -- "used by" --> Visualization_Core
+    Sequence_Utilities -- "used by" --> Prediction_Visualization
+    Sequence_Utilities -- "interacts with" --> Genome_I_O
+    Data_Handling -- "used by" --> Modisco_Interpretation
+    Data_Handling -- "used by" --> Attribution_Scoring
+    Data_Handling -- "used by" --> Simulation_Experiments
+    General_Utilities -- "used by" --> Motif_Analysis
+    General_Utilities -- "used by" --> Attribution_Scoring
+    General_Utilities -- "used by" --> Simulation_Experiments
+    General_Utilities -- "used by" --> Visualization_Core
+    General_Utilities -- "used by" --> Prediction_Visualization
+    Motif_I_O -- "used by" --> Modisco_Interpretation
+    Motif_I_O -- "used by" --> Motif_Analysis
+    Visualization_Core -- "provides plotting primitives to" --> Prediction_Visualization
+    Visualization_Core -- "uses" --> General_Utilities
+    Visualization_Core -- "uses" --> Sequence_Utilities
+    Visualization_Core -- "uses" --> Sequence_Metrics
+    Prediction_Visualization -- "formats data using" --> General_Utilities
+    Prediction_Visualization -- "receives plotting primitives from" --> Visualization_Core
+    Prediction_Visualization -- "uses" --> Sequence_Utilities
+    Prediction_Visualization -- "uses" --> Sequence_Metrics
+    Model_Core -- "provides predictions to" --> Attribution_Scoring
+    Sequence_Metrics -- "used by" --> Visualization_Core
+    Sequence_Metrics -- "used by" --> Prediction_Visualization
+    Genome_I_O -- "provides genome data to" --> Sequence_Utilities
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Model Analysis & Visualization component provides a comprehensive set of tools for interpreting and visualizing the behavior of trained models, particularly in the context of sequence analysis. Its main flow involves generating various types of attribution scores (e.g., ISM, DeepSHAP) and sequence feature analyses (e.g., MoDISco for motif discovery, motif scanning), which are then used to produce diverse visual representations such as attribution plots, ISM plots, prediction distributions, and genomic tracks. The purpose of this component is to enable researchers to gain insights into how models make predictions, identify important sequence features, and effectively communicate their findings through rich visualizations.
+
+### Modisco Interpretation
+This component is responsible for running TF-MoDISco to discover sequence motifs from input sequences and a trained model. It also handles the optional comparison of identified motifs with a reference set using TOMTOM.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/modisco.py#L188-L339" target="_blank" rel="noopener noreferrer">`grelu.interpret.modisco:run_modisco` (188:339)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/modisco.py#L15-L66" target="_blank" rel="noopener noreferrer">`grelu.interpret.modisco._ism_attrs` (15:66)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/modisco.py#L163-L185" target="_blank" rel="noopener noreferrer">`grelu.interpret.modisco._tomtom_on_modisco` (163:185)</a>
+
+
+### Motif Analysis
+This component provides functionalities for manipulating sequence motifs, scanning DNA sequences with motifs to identify binding sites, and comparing motifs using the TOMTOM algorithm.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/motifs.py#L113-L214" target="_blank" rel="noopener noreferrer">`grelu.interpret.motifs:scan_sequences` (113:214)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/motifs.py#L369-L411" target="_blank" rel="noopener noreferrer">`grelu.interpret.motifs:run_tomtom` (369:411)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/motifs.py#L217-L251" target="_blank" rel="noopener noreferrer">`grelu.interpret.motifs.score_sites` (217:251)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/motifs.py#L254-L301" target="_blank" rel="noopener noreferrer">`grelu.interpret.motifs.score_motifs` (254:301)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/motifs.py#L19-L71" target="_blank" rel="noopener noreferrer">`grelu.interpret.motifs.motifs_to_strings` (19:71)</a>
+
+
+### Attribution Scoring
+This component calculates per-nucleotide importance scores for DNA sequences using various attribution methods, including In Silico Mutagenesis (ISM), DeepSHAP, Saliency, InputXGradient, and IntegratedGradients.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/score.py#L23-L122" target="_blank" rel="noopener noreferrer">`grelu.interpret.score:ISM_predict` (23:122)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/score.py#L125-L229" target="_blank" rel="noopener noreferrer">`grelu.interpret.score:get_attributions` (125:229)</a>
+
+
+### Simulation Experiments
+This component facilitates in-silico simulation experiments, such as marginalizing patterns to assess their impact on model predictions and analyzing the effect of spacing between patterns.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/simulate.py#L9-L87" target="_blank" rel="noopener noreferrer">`grelu.interpret.simulate:marginalize_patterns` (9:87)</a>
+
+
+### Sequence Utilities
+This component provides core utility functions for handling and formatting DNA sequences, including converting input types and determining unique sequence lengths.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L86-L103" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils.get_unique_length` (86:103)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L375-L440" target="_blank" rel="noopener noreferrer">`grelu.sequence.format.convert_input_type` (375:440)</a>
+
+
+### Data Handling
+This component manages the creation and processing of specialized datasets required for model inference, particularly for In Silico Mutagenesis and pattern marginalization experiments.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L869-L938" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.ISMDataset` (869:938)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L752-L866" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.PatternMarginalizeDataset` (752:866)</a>
+
+
+### General Utilities
+This component offers a collection of general-purpose utility functions that are widely used across different modules of the gReLU system, such as list manipulation and comparison function retrieval.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/utils.py#L128-L154" target="_blank" rel="noopener noreferrer">`grelu.utils.make_list` (128:154)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/utils.py#L63-L93" target="_blank" rel="noopener noreferrer">`grelu.utils.get_compare_func` (63:93)</a>
+
+
+### Motif I/O
+This component is specifically responsible for input/output operations related to motif files, primarily focusing on reading and parsing MEME formatted motif files.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/io/motifs.py#L14-L54" target="_blank" rel="noopener noreferrer">`grelu.io.motifs.read_meme_file` (14:54)</a>
+
+
+### Visualization Core
+This component provides fundamental plotting capabilities and helper functions for generating visualizations, including adding highlights to plots and collecting prediction and label data for various visualization types.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L446-L517" target="_blank" rel="noopener noreferrer">`grelu.visualize:plot_attributions` (446:517)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L306-L357" target="_blank" rel="noopener noreferrer">`grelu.visualize.add_highlights` (306:357)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L20-L79" target="_blank" rel="noopener noreferrer">`grelu.visualize._collect_preds_and_labels` (20:79)</a>
+
+
+### Prediction Visualization
+This component focuses on generating specific visualizations related to model predictions, such as In Silico Mutagenesis plots, prediction distributions, and genomic coverage tracks.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L520-L583" target="_blank" rel="noopener noreferrer">`grelu.visualize:plot_ISM` (520:583)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L123-L157" target="_blank" rel="noopener noreferrer">`grelu.visualize:plot_pred_distribution` (123:157)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L586-L700" target="_blank" rel="noopener noreferrer">`grelu.visualize:plot_tracks` (586:700)</a>
+
+
+### Model Core
+This component encapsulates the core model architectures and functionalities for making predictions.
+
+
+**Related Classes/Methods**:
+
+- `grelu.model.models` (full file reference)
+
+
+### Sequence Metrics
+This component provides functions for calculating various metrics related to sequences.
+
+
+**Related Classes/Methods**:
+
+- `grelu.sequence.metrics` (full file reference)
+
+
+### Genome I/O
+This component handles input/output operations related to genome data.
+
+
+**Related Classes/Methods**:
+
+- `grelu.io.genome` (full file reference)
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Model Architectures.md
+++ b/.codeboarding/Model Architectures.md
@@ -1,0 +1,147 @@
+```mermaid
+graph LR
+    BaseModel["BaseModel"]
+    ConvolutionalModels["ConvolutionalModels"]
+    BorzoiModel["BorzoiModel"]
+    EnformerModel["EnformerModel"]
+    ConvTrunks["ConvTrunks"]
+    BorzoiTrunk["BorzoiTrunk"]
+    EnformerTrunk["EnformerTrunk"]
+    ConvHeads["ConvHeads"]
+    CoreBuildingBlocks["CoreBuildingBlocks"]
+    SpecializedTowers["SpecializedTowers"]
+    ConvolutionalModels -- "inherits from" --> BaseModel
+    BorzoiModel -- "inherits from" --> BaseModel
+    EnformerModel -- "inherits from" --> BaseModel
+    ConvolutionalModels -- "uses" --> ConvTrunks
+    ConvolutionalModels -- "uses" --> ConvHeads
+    BorzoiModel -- "uses" --> BorzoiTrunk
+    BorzoiModel -- "uses" --> ConvHeads
+    EnformerModel -- "uses" --> EnformerTrunk
+    EnformerModel -- "uses" --> ConvHeads
+    ConvTrunks -- "builds upon" --> CoreBuildingBlocks
+    BorzoiTrunk -- "integrates" --> SpecializedTowers
+    BorzoiTrunk -- "utilizes" --> CoreBuildingBlocks
+    EnformerTrunk -- "integrates" --> SpecializedTowers
+    EnformerTrunk -- "utilizes" --> CoreBuildingBlocks
+    ConvHeads -- "builds upon" --> CoreBuildingBlocks
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This component overview details the architecture of deep learning models within the `gReLU` project, focusing on how various feature extraction backbones (trunks) and output layers (heads) are combined to form complete, functional models. It highlights the foundational `BaseModel`, specialized model architectures like `BorzoiModel` and `EnformerModel`, and the reusable `CoreBuildingBlocks` that underpin these structures.
+
+### BaseModel
+The foundational class for all models in `gReLU`, inheriting from `torch.nn.Module`. It defines a common structure with an `embedding` module and a `head` module, and a `forward` pass that applies the embedding then the head.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L33-L56" target="_blank" rel="noopener noreferrer">`grelu.model.models.BaseModel` (33:56)</a>
+
+
+### ConvolutionalModels
+A family of models primarily built with convolutional layers, often including pooling, residual connections, batch normalization, or dilated convolutions. This group includes `ConvModel`, `DilatedConvModel`, `ConvGRUModel`, `ConvTransformerModel`, and `ConvMLPModel`.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L87-L143" target="_blank" rel="noopener noreferrer">`grelu.model.models.ConvModel:__init__` (87:143)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L146-L201" target="_blank" rel="noopener noreferrer">`grelu.model.models.DilatedConvModel` (146:201)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L204-L288" target="_blank" rel="noopener noreferrer">`grelu.model.models.ConvGRUModel` (204:288)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L291-L390" target="_blank" rel="noopener noreferrer">`grelu.model.models.ConvTransformerModel` (291:390)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L393-L472" target="_blank" rel="noopener noreferrer">`grelu.model.models.ConvMLPModel` (393:472)</a>
+
+
+### BorzoiModel
+A specific model architecture inspired by Borzoi, consisting of convolutional and transformer layers followed by U-net upsampling. It can also be loaded with pre-trained weights.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L503-L559" target="_blank" rel="noopener noreferrer">`grelu.model.models.BorzoiModel:__init__` (503:559)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L562-L626" target="_blank" rel="noopener noreferrer">`grelu.model.models.BorzoiPretrainedModel` (562:626)</a>
+
+
+### EnformerModel
+A model architecture based on the Enformer, featuring convolutional and transformer towers for sequence-to-function prediction. It also supports loading pre-trained weights.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L665-L732" target="_blank" rel="noopener noreferrer">`grelu.model.models.EnformerModel` (665:732)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L735-L790" target="_blank" rel="noopener noreferrer">`grelu.model.models.EnformerPretrainedModel` (735:790)</a>
+
+
+### ConvTrunks
+Components responsible for the initial feature extraction (embedding) using various convolutional configurations, such as standard convolutions, dilated convolutions, or combined with GRU/Transformer layers.
+
+
+**Related Classes/Methods**:
+
+- `grelu.model.trunks.ConvTrunk:__init__` (full file reference)
+- `grelu.model.trunks.DilatedConvTrunk` (full file reference)
+- `grelu.model.trunks.ConvGRUTrunk` (full file reference)
+- `grelu.model.trunks.ConvTransformerTrunk` (full file reference)
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/explainn.py#L70-L143" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.explainn.ExplaiNNTrunk` (70:143)</a>
+
+
+### BorzoiTrunk
+The embedding component specifically designed for the Borzoi model, incorporating Borzoi-specific convolutional, transformer, and U-net towers.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/borzoi.py#L129-L205" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.borzoi.BorzoiTrunk:__init__` (129:205)</a>
+
+
+### EnformerTrunk
+The embedding component specifically designed for the Enformer model, featuring Enformer-specific convolutional and transformer towers.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/enformer.py#L258-L300" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.enformer.EnformerTrunk:__init__` (258:300)</a>
+
+
+### ConvHeads
+The common output layer for many models, transforming the features extracted by the embedding trunk into task-specific predictions, often involving channel transformations and pooling. This group includes `ConvHead` and `MLPHead`.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/heads.py#L34-L61" target="_blank" rel="noopener noreferrer">`grelu.model.heads.ConvHead:__init__` (34:61)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/heads.py#L73-L156" target="_blank" rel="noopener noreferrer">`grelu.model.heads.MLPHead` (73:156)</a>
+
+
+### CoreBuildingBlocks
+Fundamental and reusable neural network layers and blocks that form the basic components of various trunks and heads. These include generic convolutional blocks, activation functions, cropping layers, and adaptive pooling.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L426-L556" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.ConvTower` (426:556)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L79-L220" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.ConvBlock` (79:220)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L223-L318" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.ChannelTransformBlock` (223:318)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L18-L60" target="_blank" rel="noopener noreferrer">`grelu.model.layers.Activation` (18:60)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L270-L305" target="_blank" rel="noopener noreferrer">`grelu.model.layers.Crop` (270:305)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L113-L148" target="_blank" rel="noopener noreferrer">`grelu.model.layers.AdaptivePool` (113:148)</a>
+
+
+### SpecializedTowers
+Complex, architecture-specific sub-components that encapsulate specialized convolutional, transformer, or U-net structures used within particular trunks.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/borzoi.py#L12-L99" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.borzoi.BorzoiConvTower` (12:99)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L780-L849" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.TransformerTower` (780:849)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L919-L951" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.UnetTower` (919:951)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/enformer.py#L14-L101" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.enformer.EnformerConvTower` (14:101)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/enformer.py#L175-L236" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.enformer.EnformerTransformerTower` (175:236)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Model Training & Prediction.md
+++ b/.codeboarding/Model Training & Prediction.md
@@ -1,0 +1,69 @@
+```mermaid
+graph LR
+    LightningModelCore["LightningModelCore"]
+    LossFunctions["LossFunctions"]
+    EvaluationMetrics["EvaluationMetrics"]
+    GeneralUtilities["GeneralUtilities"]
+    LightningModelCore -- "initializes" --> LossFunctions
+    LightningModelCore -- "initializes" --> EvaluationMetrics
+    LightningModelCore -- "uses" --> GeneralUtilities
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This component overview describes the 'Model Training & Prediction' subsystem, which leverages PyTorch Lightning to manage the entire lifecycle of deep learning models. The core functionality is encapsulated in the `LightningModelCore`, responsible for model initialization, training, and prediction. It interacts with `LossFunctions` to compute training errors, `EvaluationMetrics` to assess model performance, and `GeneralUtilities` for various data processing tasks. The primary flow involves the `LightningModelCore` initializing and utilizing these supporting components during the model's training, validation, testing, and prediction phases.
+
+### LightningModelCore
+This component encapsulates the core functionality of the gReLU deep learning model within the PyTorch Lightning framework. It handles model initialization, including building the neural network architecture, setting up loss functions, activation functions, and performance metrics. It also defines the forward pass for inference, the training step, and the prediction pipeline for datasets, including data loading and device parsing.
+
+
+**Related Classes/Methods**:
+
+- `grelu.lightning.LightningModel:__init__` (full file reference)
+- `grelu.lightning.LightningModel:training_step` (full file reference)
+- `grelu.lightning.LightningModel:predict_on_dataset` (full file reference)
+- `grelu.lightning.LightningModel.build_model` (full file reference)
+- `grelu.lightning.LightningModel.initialize_loss` (full file reference)
+- `grelu.lightning.LightningModel.initialize_activation` (full file reference)
+- `grelu.lightning.LightningModel.initialize_metrics` (full file reference)
+- `grelu.lightning.LightningModel.reset_transform` (full file reference)
+- `grelu.lightning.LightningModel:forward` (full file reference)
+- `grelu.lightning.LightningModel.format_input` (full file reference)
+- `grelu.lightning.LightningModel.make_predict_loader` (full file reference)
+- `grelu.lightning.LightningModel.parse_devices` (full file reference)
+
+
+### LossFunctions
+This component provides various loss functions used by the LightningModelCore during training. It specifically includes the PoissonMultinomialLoss, which is initialized and utilized by the model to compute the discrepancy between predicted and actual values.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/lightning/losses.py#L16-L93" target="_blank" rel="noopener noreferrer">`grelu.lightning.losses.PoissonMultinomialLoss` (16:93)</a>
+
+
+### EvaluationMetrics
+This component defines and manages the performance metrics used to evaluate the LightningModelCore. It includes metrics such as Mean Squared Error (MSE), Pearson Correlation Coefficient, and Best F1 score, which are initialized and logged by the model to track training and prediction performance.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/lightning/metrics.py#L76-L119" target="_blank" rel="noopener noreferrer">`grelu.lightning.metrics.MSE` (76:119)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/lightning/metrics.py#L122-L161" target="_blank" rel="noopener noreferrer">`grelu.lightning.metrics.PearsonCorrCoef` (122:161)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/lightning/metrics.py#L18-L73" target="_blank" rel="noopener noreferrer">`grelu.lightning.metrics.BestF1` (18:73)</a>
+
+
+### GeneralUtilities
+This component offers a collection of general-purpose utility functions that support various operations within the gReLU subsystem. These utilities include functions for aggregating data (get_aggfunc) and ensuring data is in a list format (make_list), which are leveraged by the LightningModelCore for data processing and device handling.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/utils.py#L29-L60" target="_blank" rel="noopener noreferrer">`grelu.utils.get_aggfunc` (29:60)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/utils.py#L128-L154" target="_blank" rel="noopener noreferrer">`grelu.utils.make_list` (128:154)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Neural Network Building Blocks.md
+++ b/.codeboarding/Neural Network Building Blocks.md
@@ -1,0 +1,121 @@
+```mermaid
+graph LR
+    Layers["Layers"]
+    Blocks["Blocks"]
+    Trunks["Trunks"]
+    Heads["Heads"]
+    Models["Models"]
+    Resources["Resources"]
+    Blocks -- "composes" --> Layers
+    Trunks -- "builds upon" --> Blocks
+    Heads -- "utilizes" --> Blocks
+    Heads -- "utilizes" --> Layers
+    Models -- "incorporates" --> Trunks
+    Models -- "incorporates" --> Heads
+    Models -- "retrieves artifacts from" --> Resources
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+Defines fundamental neural network layers and reusable composite blocks for constructing deep learning models. This component is structured into basic 'Layers', composite 'Blocks', feature-extracting 'Trunks', output 'Heads', and complete 'Models', with 'Resources' managing external assets.
+
+### Layers
+Provides fundamental neural network operations such as normalization, activation, pooling, attention mechanisms, and channel transformations. These are the basic building blocks used by higher-level components.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L431-L447" target="_blank" rel="noopener noreferrer">`grelu.model.layers.Attention:forward` (431:447)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L162-L195" target="_blank" rel="noopener noreferrer">`grelu.model.layers.Norm:__init__` (162:195)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L245-L267" target="_blank" rel="noopener noreferrer">`grelu.model.layers.Dropout` (245:267)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L30-L48" target="_blank" rel="noopener noreferrer">`grelu.model.layers.Activation:__init__` (30:48)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L78-L98" target="_blank" rel="noopener noreferrer">`grelu.model.layers.Pool:__init__` (78:98)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L210-L242" target="_blank" rel="noopener noreferrer">`grelu.model.layers.ChannelTransform` (210:242)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L450-L515" target="_blank" rel="noopener noreferrer">`grelu.model.layers.FlashAttention` (450:515)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L270-L305" target="_blank" rel="noopener noreferrer">`grelu.model.layers.Crop` (270:305)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L113-L148" target="_blank" rel="noopener noreferrer">`grelu.model.layers.AdaptivePool` (113:148)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/position.py#L11-L47" target="_blank" rel="noopener noreferrer">`grelu.model.position.get_central_mask` (11:47)</a>
+
+
+### Blocks
+Composes various Layers to form reusable neural network blocks. These blocks encapsulate common patterns like linear layers, convolutional layers, feed-forward networks, and transformer components, serving as intermediate building units for constructing larger network architectures.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L42-L60" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.LinearBlock:__init__` (42:60)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L113-L192" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.ConvBlock:__init__` (113:192)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L223-L318" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.ChannelTransformBlock` (223:318)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L321-L374" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.Stem` (321:374)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L559-L609" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.FeedForwardBlock` (559:609)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L612-L673" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.GRUBlock` (612:673)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L698-L757" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.TransformerBlock:__init__` (698:757)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L852-L916" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.UnetBlock` (852:916)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L426-L556" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.ConvTower` (426:556)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L780-L849" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.TransformerTower` (780:849)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L919-L951" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.UnetTower` (919:951)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L377-L423" target="_blank" rel="noopener noreferrer">`grelu.model.blocks.SeparableConv` (377:423)</a>
+
+
+### Trunks
+Represents the main feature extraction backbone of the neural network models. Trunks are typically composed of various Blocks and are responsible for processing the input data and generating high-level features before they are passed to the output heads.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/explainn.py#L7-L67" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.explainn.ExplaiNNConvBlock` (7:67)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/explainn.py#L70-L143" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.explainn.ExplaiNNTrunk` (70:143)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/borzoi.py#L12-L99" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.borzoi.BorzoiConvTower` (12:99)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/borzoi.py#L102-L223" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.borzoi.BorzoiTrunk` (102:223)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/enformer.py#L14-L101" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.enformer.EnformerConvTower` (14:101)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/enformer.py#L104-L172" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.enformer.EnformerTransformerBlock` (104:172)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/enformer.py#L175-L236" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.enformer.EnformerTransformerTower` (175:236)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/enformer.py#L239-L308" target="_blank" rel="noopener noreferrer">`grelu.model.trunks.enformer.EnformerTrunk` (239:308)</a>
+- `grelu.model.trunks.ConvTrunk` (full file reference)
+- `grelu.model.trunks.DilatedConvTrunk` (full file reference)
+- `grelu.model.trunks.ConvGRUTrunk` (full file reference)
+- `grelu.model.trunks.ConvTransformerTrunk` (full file reference)
+
+
+### Heads
+Defines the output layers of the neural network models. Heads take the features extracted by the Trunks and transform them into the final predictions or outputs of the model.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/heads.py#L19-L70" target="_blank" rel="noopener noreferrer">`grelu.model.heads.ConvHead` (19:70)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/heads.py#L73-L156" target="_blank" rel="noopener noreferrer">`grelu.model.heads.MLPHead` (73:156)</a>
+
+
+### Models
+Encapsulates complete neural network architectures by combining Trunks and Heads. These classes represent the top-level definitions of various gReLU models, handling the overall forward pass and potentially loading pretrained weights.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L59-L143" target="_blank" rel="noopener noreferrer">`grelu.model.models.ConvModel` (59:143)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L146-L201" target="_blank" rel="noopener noreferrer">`grelu.model.models.DilatedConvModel` (146:201)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L204-L288" target="_blank" rel="noopener noreferrer">`grelu.model.models.ConvGRUModel` (204:288)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L291-L390" target="_blank" rel="noopener noreferrer">`grelu.model.models.ConvTransformerModel` (291:390)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L393-L472" target="_blank" rel="noopener noreferrer">`grelu.model.models.ConvMLPModel` (393:472)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L475-L559" target="_blank" rel="noopener noreferrer">`grelu.model.models.BorzoiModel` (475:559)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L562-L626" target="_blank" rel="noopener noreferrer">`grelu.model.models.BorzoiPretrainedModel` (562:626)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L629-L662" target="_blank" rel="noopener noreferrer">`grelu.model.models.ExplaiNNModel` (629:662)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L665-L732" target="_blank" rel="noopener noreferrer">`grelu.model.models.EnformerModel` (665:732)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L735-L790" target="_blank" rel="noopener noreferrer">`grelu.model.models.EnformerPretrainedModel` (735:790)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L38-L42" target="_blank" rel="noopener noreferrer">`grelu.model.models.BaseModel.__init__` (38:42)</a>
+
+
+### Resources
+Manages external resources, such as retrieving pre-trained model artifacts.
+
+
+**Related Classes/Methods**:
+
+- `grelu.resources.get_artifact` (full file reference)
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Sequence Design & Optimization.md
+++ b/.codeboarding/Sequence Design & Optimization.md
@@ -1,0 +1,138 @@
+```mermaid
+graph LR
+    Sequence_Design_Optimization["Sequence Design & Optimization"]
+    Model_Training_Evaluation["Model Training & Evaluation"]
+    Dataset_Management["Dataset Management"]
+    Sequence_Formatting["Sequence Formatting"]
+    General_Utilities["General Utilities"]
+    Sequence_Mutation["Sequence Mutation"]
+    Model_Architecture["Model Architecture"]
+    Data_Augmentation["Data Augmentation"]
+    Sequence_Utilities["Sequence Utilities"]
+    Data_Transformations["Data Transformations"]
+    Sequence_Design_Optimization -- "uses" --> Model_Training_Evaluation
+    Sequence_Design_Optimization -- "orchestrates" --> Dataset_Management
+    Sequence_Design_Optimization -- "relies on" --> Sequence_Formatting
+    Sequence_Design_Optimization -- "applies" --> Data_Transformations
+    Sequence_Design_Optimization -- "uses" --> General_Utilities
+    Model_Training_Evaluation -- "uses" --> Dataset_Management
+    Model_Training_Evaluation -- "defines" --> Model_Architecture
+    Dataset_Management -- "utilizes" --> Sequence_Formatting
+    Dataset_Management -- "employs" --> Sequence_Utilities
+    Dataset_Management -- "integrates" --> Data_Augmentation
+    Dataset_Management -- "applies" --> Sequence_Mutation
+    Sequence_Formatting -- "leverages" --> Sequence_Utilities
+    Sequence_Mutation -- "requires" --> Sequence_Formatting
+    Sequence_Mutation -- "uses" --> Sequence_Utilities
+    Data_Augmentation -- "invokes" --> Sequence_Mutation
+    Data_Augmentation -- "leverages" --> Sequence_Utilities
+    Data_Transformations -- "used by" --> Sequence_Design_Optimization
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The `grelu` system focuses on the design and analysis of biological sequences, particularly DNA. Its core purpose is to enable the directed evolution and optimization of novel sequences using deep learning models. This involves a workflow where sequences are formatted, processed into datasets, fed into trained models for prediction, and then iteratively mutated and evaluated to achieve desired properties. The system integrates various utility components for sequence manipulation, data augmentation, and result interpretation, all underpinned by robust model architectures and training pipelines.
+
+### Sequence Design & Optimization
+Implements algorithms and workflows for the directed design and optimization of novel biological sequences, leveraging trained deep learning models.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/design.py#L19-L215" target="_blank" rel="noopener noreferrer">`grelu.design.evolve` (19:215)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/design.py#L219-L292" target="_blank" rel="noopener noreferrer">`grelu.design.ledidi` (219:292)</a>
+
+
+### Model Training & Evaluation
+Encapsulates the functionalities for training, validating, and evaluating deep learning models using PyTorch Lightning.
+
+
+**Related Classes/Methods**:
+
+- `grelu.lightning.LightningModel` (full file reference)
+
+
+### Dataset Management
+Responsible for creating and managing different types of sequence datasets, facilitating data loading and access for model training and inference.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L452-L530" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.SeqDataset` (452:530)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L869-L938" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.ISMDataset` (869:938)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L941-L1000" target="_blank" rel="noopener noreferrer">`grelu.data.dataset.MotifScanDataset` (941:1000)</a>
+
+
+### Sequence Formatting
+This component is responsible for validating and converting DNA sequences between various accepted formats.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L375-L440" target="_blank" rel="noopener noreferrer">`grelu.sequence.format.convert_input_type` (375:440)</a>
+
+
+### General Utilities
+This component provides miscellaneous utility functions that are broadly applicable across different parts of the `grelu` system.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/utils.py#L128-L154" target="_blank" rel="noopener noreferrer">`grelu.utils.make_list` (128:154)</a>
+
+
+### Sequence Mutation
+This component provides functionalities for introducing mutations into DNA sequences, crucial for sequence design and augmentation processes.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/mutate.py#L12-L57" target="_blank" rel="noopener noreferrer">`grelu.sequence.mutate.mutate` (12:57)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/mutate.py#L170-L224" target="_blank" rel="noopener noreferrer">`grelu.sequence.mutate.random_mutate` (170:224)</a>
+
+
+### Model Architecture
+This component defines and implements the deep learning model architectures used for sequence analysis.
+
+
+**Related Classes/Methods**:
+
+- `grelu.model.models` (full file reference)
+
+
+### Data Augmentation
+This component implements various data augmentation techniques for DNA sequences to expand and diversify training datasets.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/augment.py#L95-L245" target="_blank" rel="noopener noreferrer">`grelu.data.augment.Augmenter` (95:245)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/augment.py#L65-L77" target="_blank" rel="noopener noreferrer">`grelu.data.augment.rc_seq` (65:77)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/augment.py#L50-L62" target="_blank" rel="noopener noreferrer">`grelu.data.augment.shift` (50:62)</a>
+
+
+### Sequence Utilities
+This component offers fundamental utility functions for manipulating DNA sequences, including operations like getting sequence lengths, padding, and trimming.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L24-L66" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils.get_lengths` (24:66)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L106-L189" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils.pad` (106:189)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L192-L260" target="_blank" rel="noopener noreferrer">`grelu.sequence.utils.trim` (192:260)</a>
+
+
+### Data Transformations
+This component provides various transformation functions for labels, predictions, and sequences, used for data processing and model output interpretation.
+
+
+**Related Classes/Methods**:
+
+- `grelu.transforms.prediction_transforms` (full file reference)
+- `grelu.transforms.seq_transforms` (full file reference)
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,149 @@
+```mermaid
+graph LR
+    Data_Management_Preparation["Data Management & Preparation"]
+    Neural_Network_Building_Blocks["Neural Network Building Blocks"]
+    Model_Architectures["Model Architectures"]
+    Model_Training_Prediction["Model Training & Prediction"]
+    Model_Analysis_Visualization["Model Analysis & Visualization"]
+    Sequence_Design_Optimization["Sequence Design & Optimization"]
+    Core_Resource_Utilities["Core & Resource Utilities"]
+    Data_Management_Preparation -- "provides data to" --> Model_Training_Prediction
+    Data_Management_Preparation -- "provides data to" --> Model_Analysis_Visualization
+    Neural_Network_Building_Blocks -- "composes" --> Model_Architectures
+    Model_Architectures -- "uses" --> Neural_Network_Building_Blocks
+    Model_Architectures -- "provides models to" --> Model_Training_Prediction
+    Model_Training_Prediction -- "consumes data from" --> Data_Management_Preparation
+    Model_Training_Prediction -- "utilizes" --> Model_Architectures
+    Model_Training_Prediction -- "generates outputs for" --> Model_Analysis_Visualization
+    Model_Analysis_Visualization -- "interprets outputs from" --> Model_Training_Prediction
+    Model_Analysis_Visualization -- "processes data from" --> Data_Management_Preparation
+    Sequence_Design_Optimization -- "leverages" --> Model_Training_Prediction
+    Sequence_Design_Optimization -- "operates on" --> Data_Management_Preparation
+    Core_Resource_Utilities -- "supports" --> Data_Management_Preparation
+    Core_Resource_Utilities -- "manages resources for" --> Model_Architectures
+    Core_Resource_Utilities -- "provides utilities to" --> Model_Training_Prediction
+    Core_Resource_Utilities -- "assists" --> Model_Analysis_Visualization
+    Core_Resource_Utilities -- "aids" --> Sequence_Design_Optimization
+    click Data_Management_Preparation href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/gReLU/Data Management & Preparation.md" "Details"
+    click Neural_Network_Building_Blocks href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/gReLU/Neural Network Building Blocks.md" "Details"
+    click Model_Architectures href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/gReLU/Model Architectures.md" "Details"
+    click Model_Training_Prediction href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/gReLU/Model Training & Prediction.md" "Details"
+    click Model_Analysis_Visualization href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/gReLU/Model Analysis & Visualization.md" "Details"
+    click Sequence_Design_Optimization href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/gReLU/Sequence Design & Optimization.md" "Details"
+    click Core_Resource_Utilities href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/gReLU/Core & Resource Utilities.md" "Details"
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The `gReLU` project provides a comprehensive framework for deep learning analysis of biological sequences. It encompasses modules for efficient data management and preparation, robust neural network construction, streamlined model training and prediction, and advanced interpretation and visualization of model outputs. Additionally, it supports sequence design and leverages core utilities for various common tasks and external resource management.
+
+### Data Management & Preparation
+Manages all aspects of biological sequence data, including reading, basic manipulation, augmentation, variant processing, and providing abstract dataset interfaces for model consumption.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/mutate.py#L12-L57" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.sequence.mutate:mutate` (12:57)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/io/fasta.py#L29-L50" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.io.fasta:read_fasta` (29:50)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/augment.py#L188-L245" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.data.augment.Augmenter:__call__` (188:245)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/variant.py#L104-L139" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.variant:variant_to_seqs` (104:139)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/metrics.py#L14-L62" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.sequence.metrics:gc` (14:62)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/format.py#L113-L157" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.sequence.format:get_input_type` (113:157)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/sequence/utils.py#L24-L66" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.sequence.utils:get_lengths` (24:66)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/io/genome.py#L13-L33" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.io.genome:read_sizes` (13:33)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/io/bigwig.py#L31-L99" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.io.bigwig:read_bigwig` (31:99)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/preprocess.py#L73-L142" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.data.preprocess:filter_coverage` (73:142)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L72-L156" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.data.dataset.LabeledSeqDataset:__init__` (72:156)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L252-L300" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.data.dataset.DFSeqDataset:__init__` (252:300)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L548-L582" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.data.dataset.VariantDataset:__init__` (548:582)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L883-L904" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.data.dataset.ISMDataset:__init__` (883:904)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/data/dataset.py#L955-L983" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.data.dataset.MotifScanDataset:__init__` (955:983)</a>
+
+
+### Neural Network Building Blocks
+Defines fundamental neural network layers and reusable composite blocks for constructing deep learning models.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L431-L447" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.layers.Attention:forward` (431:447)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L113-L192" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.blocks.ConvBlock:__init__` (113:192)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L30-L48" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.layers.Activation:__init__` (30:48)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L78-L98" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.layers.Pool:__init__` (78:98)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/layers.py#L162-L195" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.layers.Norm:__init__` (162:195)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L42-L60" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.blocks.LinearBlock:__init__` (42:60)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/blocks.py#L698-L757" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.blocks.TransformerBlock:__init__` (698:757)</a>
+
+
+### Model Architectures
+Encapsulates complete deep learning model architectures, combining various feature extraction backbones (trunks) and output layers (heads) to form functional models.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/borzoi.py#L129-L205" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.trunks.borzoi.BorzoiTrunk:__init__` (129:205)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/heads.py#L34-L61" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.heads.ConvHead:__init__` (34:61)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L87-L143" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.models.ConvModel:__init__` (87:143)</a>
+- `gReLU.src.grelu.model.trunks.ConvTrunk:__init__` (full file reference)
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/trunks/enformer.py#L258-L300" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.trunks.enformer.EnformerTrunk:__init__` (258:300)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/model/models.py#L503-L559" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.model.models.BorzoiModel:__init__` (503:559)</a>
+
+
+### Model Training & Prediction
+Provides the PyTorch Lightning interface for managing the entire lifecycle of deep learning models, including training, validation, testing, and prediction workflows.
+
+
+**Related Classes/Methods**:
+
+- `gReLU.src.grelu.lightning.LightningModel:__init__` (full file reference)
+- `gReLU.src.grelu.lightning.LightningModel:training_step` (full file reference)
+- `gReLU.src.grelu.lightning.LightningModel:predict_on_dataset` (full file reference)
+
+
+### Model Analysis & Visualization
+Offers a comprehensive suite of tools for interpreting model behavior, analyzing sequence features (e.g., attribution, motifs, MoDISco, pattern simulation), and generating various plots and visual representations of data and results.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/modisco.py#L188-L339" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.modisco:run_modisco` (188:339)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/motifs.py#L113-L214" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.motifs:scan_sequences` (113:214)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/score.py#L23-L122" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.score:ISM_predict` (23:122)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/simulate.py#L9-L87" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.simulate:marginalize_patterns` (9:87)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/score.py#L125-L229" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.score:get_attributions` (125:229)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/interpret/motifs.py#L369-L411" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.interpret.motifs:run_tomtom` (369:411)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L446-L517" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.visualize:plot_attributions` (446:517)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L520-L583" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.visualize:plot_ISM` (520:583)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L123-L157" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.visualize:plot_pred_distribution` (123:157)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/visualize.py#L586-L700" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.visualize:plot_tracks` (586:700)</a>
+
+
+### Sequence Design & Optimization
+Implements algorithms and workflows for the directed design and optimization of novel biological sequences, leveraging trained deep learning models.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/design.py#L19-L215" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.design:evolve` (19:215)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/design.py#L219-L292" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.design:ledidi` (219:292)</a>
+
+
+### Core & Resource Utilities
+Provides general-purpose helper functions, specialized data/prediction transformation utilities, and manages access to external resources like pre-trained models and datasets.
+
+
+**Related Classes/Methods**:
+
+- `gReLU.src.grelu.resources:get_artifact` (full file reference)
+- `gReLU.src.grelu.resources:load_model` (full file reference)
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/utils.py#L63-L93" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.utils:get_compare_func` (63:93)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/transforms/prediction_transforms.py#L39-L92" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.transforms.prediction_transforms.Aggregate:__init__` (39:92)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/utils.py#L128-L154" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.utils:make_list` (128:154)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/transforms/label_transforms.py#L25-L33" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.transforms.label_transforms.LabelTransform:__init__` (25:33)</a>
+- <a href="https://github.com/Genentech/gReLU/blob/master/src/grelu/transforms/seq_transforms.py#L54-L55" target="_blank" rel="noopener noreferrer">`gReLU.src.grelu.transforms.seq_transforms.PatternScore:__call__` (54:55)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR contains mermaid driven diagram high-level visualization of the gReLU codebase.
You can see how the diagrams render in github in this link: 
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/gReLU/on_boarding.md

I can see that you already have a diagram representing the process of gReLU in your readme. Me and a friend with whom I am working on this believe that diagrams are the easiest way for someone to get started with a codebase. We generate ours with static analysis and LLMs. The diagram is aimed at helping people get up-to-speed with the existing codebase, by giving a good overview of the existing components and how they interact with eachother further also linking to the relevant parts of the code itself. I would love to hear what is your current process for helping people getting started in the company and if you think that our diagrams can be of use!