### PR TITLE
fix: correct `filter_overlapping` for dtype mismatch

### DIFF
--- a/src/grelu/data/preprocess.py
+++ b/src/grelu/data/preprocess.py
@@ -326,7 +326,7 @@ def filter_overlapping(
         ]
 
     # list intervals to keep
-    keep = intervals.index.isin(overlap["index"])
+    keep = intervals.index.astype(overlap["index"].dtype).isin(overlap["index"]).to_numpy()
     if invert:
         keep = ~keep
 


### PR DESCRIPTION
Fixed a bug in `filter_overlapping` when `interval.index` and `overlap["index"]` had different `dtype`. This could happen when the `intervals.index` was numeric (e.g., `1, 2, 3, 4, ...`) but was stored as strings (e.g., `"1", "2", "3", "4", ...`).

I attach an example following the [finetune tutorial](https://genentech.github.io/gReLU/tutorials/2_finetune.html): 
[debug-filter_blacklist.ipynb.zip](https://github.com/user-attachments/files/21420053/debug-filter_blacklist.ipynb.zip)
