### PR TITLE
Fix update_ckpt() failing on legacy checkpoints with torch >= 2.6

### DIFF
--- a/src/grelu/io/__init__.py
+++ b/src/grelu/io/__init__.py
@@ -54,8 +54,10 @@ def update_ckpt(ckpt_file: str, out_file: Optional[str] = None) -> None:
     import torch
     from pytorch_lightning.utilities.migration import migrate_checkpoint
 
-    # Load old checkpoint
-    ckpt = torch.load(ckpt_file, map_location="cpu")
+    # Load old checkpoint. Legacy gReLU checkpoints store numpy values in
+    # "performance", which the weights_only=True default of PyTorch >= 2.6
+    # refuses to unpickle.
+    ckpt = torch.load(ckpt_file, map_location="cpu", weights_only=False)
 
     # Update pytorch version
     ckpt, _ = migrate_checkpoint(ckpt)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -690,3 +690,60 @@ def test_read_modisco_report():
     vals = list(output.values())
     assert np.allclose(vals[0], expected_pos_patterns[0][:, 9:11])
     assert np.allclose(vals[1], expected_pos_patterns[1][:, 19:23])
+
+
+def test_update_ckpt(tmp_path):
+    # Legacy checkpoints written by gReLU carry numpy scalars in "performance"
+    # (LightningModel.on_save_checkpoint), which torch.load refuses under the
+    # weights_only=True default of PyTorch >= 2.6. update_ckpt must still be
+    # able to open them.
+    import pytorch_lightning as pl
+    import torch
+
+    from grelu.io import update_ckpt
+    from grelu.lightning import LightningModel
+
+    model_params = {
+        "model_type": "ConvModel",
+        "n_tasks": 1,
+        "n_conv": 1,
+        "channel_init": 8,
+        "stem_kernel_size": 3,
+        "kernel_size": 3,
+        "act_func": "relu",
+        "norm": False,
+        "final_pool_func": "avg",
+    }
+    train_params = {
+        "task": "regression",
+        "loss": "MSE",
+        "lr": 1e-3,
+        "batch_size": 2,
+        "max_epochs": 1,
+    }
+    ckpt_file = str(tmp_path / "legacy.ckpt")
+    model = LightningModel(model_params=model_params, train_params=train_params)
+    trainer = pl.Trainer(
+        accelerator="cpu",
+        devices=1,
+        max_epochs=1,
+        logger=False,
+        enable_checkpointing=False,
+    )
+    trainer.strategy.connect(model)
+    trainer.save_checkpoint(ckpt_file)
+
+    # Reproduce the legacy on-disk state: numpy metric values in "performance"
+    # and the pre-rename "depth" hyperparameter
+    ckpt = torch.load(ckpt_file, map_location="cpu", weights_only=False)
+    ckpt["performance"] = {"val": {"pearson": np.float64(0.87)}}
+    ckpt["hyper_parameters"]["model_params"]["depth"] = 0
+    torch.save(ckpt, ckpt_file)
+
+    out_file = str(tmp_path / "updated.ckpt")
+    update_ckpt(ckpt_file, out_file)
+
+    updated = torch.load(out_file, map_location="cpu", weights_only=False)
+    assert updated["hyper_parameters"]["model_params"]["n_transformers"] == 0
+    assert "depth" not in updated["hyper_parameters"]["model_params"]
+    assert updated["performance"] == {"val": {"pearson": np.float64(0.87)}}


### PR DESCRIPTION
Fixes #193.

`update_ckpt()` is the documented migration path for checkpoints saved with gReLU v0.4 or lower, but on PyTorch 2.6+ it raises `UnpicklingError` on exactly those files: PyTorch 2.6 flipped the default of `torch.load`'s `weights_only` argument to `True`, and legacy gReLU checkpoints carry numpy metric values in `performance` (written by `LightningModel.on_save_checkpoint`), which the safe unpickler refuses.

The fix loads the checkpoint with an explicit `weights_only=False`, matching the default `grelu.resources.wandb.load_model_from_wandb` already uses for checkpoint loading. `update_ckpt` reads files the user is explicitly asking to migrate, the same trust model as before PyTorch 2.6.

Added a regression test that builds a checkpoint the way gReLU writes them, injects numpy `performance` values and the legacy `depth` hyperparameter, and runs `update_ckpt` end to end. Verified with torch 2.13.0 / lightning 2.6.5 / numpy 2.5.2:

* against current `main`, the test fails with `UnpicklingError: Weights only load failed ... GLOBAL numpy._core.multiarray.scalar was not an allowed global`;
* with this change it passes, and the rest of `tests/test_io.py` still passes.

The other `torch.load` calls in the codebase (`grelu/model/models.py`) load plain tensor state dicts, which the `weights_only=True` default handles fine, so they are left unchanged.
