### PR TITLE
Fix predict_on_seqs OOM via batched Trainer.predict

### DIFF
--- a/src/grelu/lightning/__init__.py
+++ b/src/grelu/lightning/__init__.py
@@ -770,26 +770,54 @@ class LightningModel(pl.LightningModule):
     def predict_on_seqs(
         self,
         x: Union[str, List[str]],
-        device: Union[str, int] = "cpu",
+        devices: Union[int, str, List[int]] = "cpu",
+        num_workers: int = 1,
+        batch_size: int = 1,
+        precision: Optional[str] = None,
+        device: Optional[Union[str, int, List[int]]] = None,
     ) -> np.ndarray:
         """
         A simple function to return model predictions directly
-        on a batch of a single batch of sequences in string
-        format.
+        on a single sequence in string format or on multiple
+        sequences in a list of strings.
+
+        This uses the same batched Lightning ``Trainer.predict`` path as
+        ``predict_on_dataset``, avoiding loading the full batch onto the
+        device at once (which can OOM for large models).
 
         Args:
             x: DNA sequences as a string or list of strings.
-            device: Index of the device to use
+            devices: Device IDs to use
+            num_workers: Number of workers for data loader
+            batch_size: Batch size for data loader
+            precision: Precision of the trainer e.g. '32' or 'bf16-mixed'.
+            device: Alias for ``devices`` (kept for backward compatibility
+                with older call sites that pass ``device=``).
 
         Returns:
             A numpy array of predictions.
         """
+        if device is not None:
+            devices = device
+
+        torch.set_float32_matmul_precision("medium")
         x = strings_to_one_hot(x, add_batch_axis=True)
-        x = x.to(device)
-        self.model = self.model.eval().to(device)
-        preds = self.forward(x).detach().cpu().numpy()
-        self.model = self.model.cpu()
-        return preds
+        dataloader = self.make_predict_loader(
+            x,
+            num_workers=num_workers,
+            batch_size=batch_size,
+        )
+        accelerator, devices = self.parse_devices(devices)
+        trainer = pl.Trainer(
+            accelerator=accelerator,
+            devices=devices,
+            logger=None,
+            precision=precision,
+        )
+
+        # Predict
+        preds = torch.concat(trainer.predict(self, dataloader))
+        return preds.detach().cpu().numpy()
 
     def predict_on_dataset(
         self,

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -218,13 +218,27 @@ def test_lightning_model_predict_on_dataset():
 
 
 def test_lightning_model_predict_on_seqs():
+    expected_single = single_task_reg_model(one_hot[[0]]).detach().numpy()
+    expected_multi = single_task_reg_model(one_hot).detach().numpy()
+
     assert np.allclose(
         single_task_reg_model.predict_on_seqs(strings[0]),
-        single_task_reg_model(one_hot[[0]]).detach().numpy(),
+        expected_single,
     )
     assert np.allclose(
         single_task_reg_model.predict_on_seqs(strings),
-        single_task_reg_model(one_hot).detach().numpy(),
+        expected_multi,
+    )
+    # Batched path and backward-compatible device= alias
+    assert np.allclose(
+        single_task_reg_model.predict_on_seqs(
+            strings, devices="cpu", batch_size=1, num_workers=0
+        ),
+        expected_multi,
+    )
+    assert np.allclose(
+        single_task_reg_model.predict_on_seqs(strings, device="cpu", batch_size=2),
+        expected_multi,
     )
 
 


### PR DESCRIPTION
## Summary
- Fixes #154: `predict_on_seqs` eagerly moved the full one-hot batch onto the device and ran a single forward pass, which OOMs on large models (e.g. Borzoi in `1_inference.ipynb` on 16GB VRAM).
- Aligns `predict_on_seqs` with `predict_on_dataset` / `ISM_predict` by using `make_predict_loader` + Lightning `Trainer.predict` so inference is batched.
- Adds optional `devices`, `num_workers`, `batch_size`, and `precision` kwargs (defaults: `batch_size=1` for memory safety on large models).
- Keeps the `device=` keyword as a backward-compatible alias so existing tutorials (`predict_on_seqs(..., device=0)`) continue to work.

## Test plan
- [x] `pytest tests/test_lightning.py::test_lightning_model_predict_on_seqs` (CPU; covers single/multi seqs, `devices=`, `device=` alias, and `batch_size`)
- [x] `pytest tests/test_lightning.py::test_lightning_model_predict_on_dataset` still passes
- [ ] Optional: re-run Borzoi `predict_on_seqs` from `docs/tutorials/1_inference.ipynb` on a 16GB GPU