### PR TITLE
Accept interval columns by name regardless of order

### DIFF
--- a/src/grelu/data/dataset.py
+++ b/src/grelu/data/dataset.py
@@ -263,9 +263,10 @@ class DFSeqDataset(LabeledSeqDataset):
     ) -> None:
         # Separate the sequences and labels
         if check_intervals(df):
-            print(f"Sequences will be extracted from columns {df.columns[:3].tolist()}")
-            seqs = df.iloc[:, :3]
-            labels = df.iloc[:, 3:]
+            interval_cols = ["chrom", "start", "end"]
+            print(f"Sequences will be extracted from columns {interval_cols}")
+            seqs = df[interval_cols]
+            labels = df.drop(columns=interval_cols)
         else:
             print(f"Sequences will be extracted from columns {df.columns[:1].tolist()}")
             seqs = df.iloc[:, 0].tolist()

--- a/src/grelu/sequence/format.py
+++ b/src/grelu/sequence/format.py
@@ -3,7 +3,7 @@
 input DNA sequences and converting them between accepted sequence formats.
 
 The following are accepted sequence formats in gReLU:
-1. intervals: a pd.DataFrame object containing valid genomic intervals
+1. intervals: a pd.DataFrame object containing valid genomic intervals (columns "chrom", "start", "end" by name; order does not matter)
 2. strings: A string or list of strings
 3. indices: A numpy array of shape (length,) or (N, length) and dtype np.int8
 4. one_hot: A torch tensor of shape (4, length) or (N, 4, length) and dtype torch.float32
@@ -33,22 +33,25 @@ def check_intervals(df: pd.DataFrame) -> bool:
     """
     Check if a pandas dataframe contains valid genomic intervals.
 
+    Required columns are identified by name ("chrom", "start", "end");
+    column order does not matter, and additional columns are allowed.
+
     Args:
         df: Dataframe to check
 
     Returns:
         Whether the dataframe contains valid genomic intervals
     """
-    # Check if required columns are included
-    if df.shape[1] >= 3:
-        if np.all(df.columns[:3] == ["chrom", "start", "end"]):
-            # Check column dtypes
-            if (
-                (is_string_dtype(df.chrom) or is_categorical_dtype(df.chrom))
-                and (is_integer_dtype(df.start))
-                and (is_integer_dtype(df.end))
-            ):
-                return True
+    # Check if required columns are included (order-independent)
+    required = ["chrom", "start", "end"]
+    if all(col in df.columns for col in required):
+        # Check column dtypes
+        if (
+            (is_string_dtype(df["chrom"]) or is_categorical_dtype(df["chrom"]))
+            and (is_integer_dtype(df["start"]))
+            and (is_integer_dtype(df["end"]))
+        ):
+            return True
     return False
 
 

--- a/src/grelu/sequence/utils.py
+++ b/src/grelu/sequence/utils.py
@@ -261,18 +261,21 @@ def trim(
 
 
 def resize(
-    seqs: Union[str, List[str], np.ndarray],
+    seqs: Union[pd.DataFrame, str, List[str], np.ndarray],
     seq_len: int,
     end: str = "both",
     input_type: Optional[str] = None,
-) -> Union[str, List[str], np.ndarray]:
+) -> Union[pd.DataFrame, str, List[str], np.ndarray]:
     """
     Resize the given sequences to the desired length (`seq_len`).
     Sequences shorter than seq_len will be padded with Ns. Sequences longer
     than seq_len will be trimmed.
 
     Args:
-        seqs: DNA sequences as intervals, strings, or integer encoded format
+        seqs: DNA sequences as intervals, strings, or integer encoded format.
+            Interval inputs should be a pandas DataFrame containing columns
+            named "chrom", "start", and "end" (column order does not matter;
+            additional columns are preserved).
         seq_len: Desired length of output sequences.
         end: Which end of the sequence to trim or extend. Accepted values are
             "left", "right" or "both".

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -25,6 +25,23 @@ def test_get_input_type():
     df = pd.DataFrame({"chrom": ["chr1", "chr2"], "start": [10, 20], "end": [20, 30]})
     assert get_input_type(df) == "intervals"
 
+    # Column order should not matter for interval dataframes
+    df_reordered = pd.DataFrame(
+        {"end": [20, 30], "chrom": ["chr1", "chr2"], "start": [10, 20]}
+    )
+    assert get_input_type(df_reordered) == "intervals"
+
+    # Extra columns are allowed alongside chrom/start/end
+    df_extra = pd.DataFrame(
+        {
+            "name": ["a", "b"],
+            "chrom": ["chr1", "chr2"],
+            "start": [10, 20],
+            "end": [20, 30],
+        }
+    )
+    assert get_input_type(df_extra) == "intervals"
+
     # Test invalid dataframe input
     df_missing_cols = pd.DataFrame({"chrom": ["chr1", "chr2"]})
     with pytest.raises(ValueError):
@@ -291,6 +308,22 @@ def test_resize():
         {"chrom": ["chr1", "chr1"], "start": [14998, 15008], "end": [15006, 15016]}
     )
     assert np.all(resize(intervals, seq_len=8) == resized_intervals)
+
+    # Interval input with out-of-order columns (and an extra column)
+    intervals_reordered = pd.DataFrame(
+        {
+            "name": ["x", "y"],
+            "end": [15003, 15013],
+            "chrom": ["chr1", "chr1"],
+            "start": [15000, 15010],
+        }
+    )
+    resized_reordered = resize(intervals_reordered, seq_len=8)
+    assert list(resized_reordered.columns) == ["name", "end", "chrom", "start"]
+    assert np.all(resized_reordered["chrom"] == ["chr1", "chr1"])
+    assert np.all(resized_reordered["start"] == [14998, 15008])
+    assert np.all(resized_reordered["end"] == [15006, 15016])
+    assert np.all(resized_reordered["name"] == ["x", "y"])
 
 
 def test_random_generation():


### PR DESCRIPTION
## Summary
- `check_intervals` now validates `chrom` / `start` / `end` by column name (order-independent), so `grelu.sequence.utils.resize` and other callers no longer fail when those columns are present but reordered.
- Updated `resize` / format docstrings to document name-based interval columns; `DFSeqDataset` also selects interval columns by name for consistency.
- Added unit tests for out-of-order (and extra) interval columns in `get_input_type` and `resize`.

Fixes #34

## Test plan
- [x] `pytest tests/test_sequence.py::test_get_input_type tests/test_sequence.py::test_resize`
- [ ] Confirm tutorial-style dataframe with columns like `name, end, chrom, start` works with `resize`